### PR TITLE
[Feat] Button 공통 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
@@ -132,7 +132,7 @@ fun FlintButton(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 private fun FlintButtonPreview() {
     FlintTheme {

--- a/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
@@ -32,12 +32,26 @@ import androidx.compose.ui.unit.dp
 import com.flint.R
 import com.flint.core.designsystem.theme.FlintTheme
 
-enum class FlintButtonType(
-    val verticalPadding: Dp,
-    val minHeight: Dp,
-) {
-    Large(verticalPadding = 0.dp, minHeight = 48.dp),
-    Medium(verticalPadding = 2.dp, minHeight = 44.dp),
+sealed interface FlintButtonType {
+    val verticalPadding: Dp
+    val minHeight: Dp
+
+    object Large : FlintButtonType {
+        override val verticalPadding = 0.dp
+        override val minHeight = 48.dp
+    }
+
+    object Medium : FlintButtonType {
+        override val verticalPadding = 2.dp
+        override val minHeight = 44.dp
+    }
+
+    class Icon(
+        val icon: Painter,
+    ) : FlintButtonType {
+        override val verticalPadding = 2.dp
+        override val minHeight = 44.dp
+    }
 }
 
 enum class FlintButtonState(
@@ -86,10 +100,14 @@ fun FlintButton(
     state: FlintButtonState,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    leadingIcon: Painter? = null,
 ) {
     val verticalPadding: Dp = type.verticalPadding
     val minHeight: Dp = type.minHeight
+    val leadingIcon: Painter? =
+        when (type) {
+            is FlintButtonType.Icon -> type.icon
+            else -> null
+        }
     val enabled: Boolean = state.enabled
     val background: Brush = state.background
     val contentColor: Color = state.contentColor
@@ -218,33 +236,30 @@ private fun FlintButtonPreview() {
             Row {
                 FlintButton(
                     text = "공개",
-                    type = FlintButtonType.Medium,
+                    type = FlintButtonType.Icon(painterResource(R.drawable.ic_share)),
                     state = FlintButtonState.Disable,
                     onClick = {},
                     modifier = Modifier.weight(1f),
-                    leadingIcon = painterResource(R.drawable.ic_share),
                 )
 
                 Spacer(Modifier.width(16.dp))
 
                 FlintButton(
                     text = "공개",
-                    type = FlintButtonType.Medium,
+                    type = FlintButtonType.Icon(painterResource(R.drawable.ic_share)),
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
                     modifier = Modifier.weight(1f),
-                    leadingIcon = painterResource(R.drawable.ic_share),
                 )
             }
 
             Row {
                 FlintButton(
                     text = "공개",
-                    type = FlintButtonType.Medium,
+                    type = FlintButtonType.Icon(painterResource(R.drawable.ic_share)),
                     state = FlintButtonState.Outline,
                     onClick = {},
                     modifier = Modifier.weight(0.5f),
-                    leadingIcon = painterResource(R.drawable.ic_share),
                 )
 
                 Spacer(Modifier.width(16.dp))

--- a/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
@@ -1,0 +1,253 @@
+package com.flint.core.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.theme.FlintTheme
+
+enum class FlintButtonType(
+    val verticalPadding: Dp,
+    val minHeight: Dp,
+) {
+    Large(verticalPadding = 0.dp, minHeight = 48.dp),
+    Medium(verticalPadding = 2.dp, minHeight = 44.dp),
+}
+
+enum class FlintButtonState(
+    val enabled: Boolean,
+) {
+    Able(enabled = true),
+    Disable(enabled = false),
+    Outline(enabled = true),
+    ColorOutline(enabled = true),
+    ;
+
+    val background: Brush
+        @Composable
+        @ReadOnlyComposable
+        get() =
+            when (this) {
+                Able -> FlintTheme.colors.gradient400
+                Disable -> SolidColor(FlintTheme.colors.gray700)
+                Outline, ColorOutline -> SolidColor(FlintTheme.colors.gray800)
+            }
+
+    val contentColor: Color
+        @Composable
+        @ReadOnlyComposable
+        get() =
+            when (this) {
+                Able, Outline, ColorOutline -> FlintTheme.colors.white
+                Disable -> FlintTheme.colors.gray400
+            }
+
+    val border: BorderStroke?
+        @Composable
+        @ReadOnlyComposable
+        get() =
+            when (this) {
+                Outline -> BorderStroke(2.dp, FlintTheme.colors.gray500)
+                ColorOutline -> BorderStroke(2.dp, FlintTheme.colors.primary400)
+                else -> null
+            }
+}
+
+@Composable
+fun FlintButton(
+    text: String,
+    type: FlintButtonType,
+    state: FlintButtonState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    leadingIcon: Painter? = null,
+) {
+    val verticalPadding: Dp = type.verticalPadding
+    val minHeight: Dp = type.minHeight
+    val enabled: Boolean = state.enabled
+    val background: Brush = state.background
+    val contentColor: Color = state.contentColor
+    val border: BorderStroke? = state.border
+    val shape = RoundedCornerShape(8.dp)
+
+    Row(
+        modifier =
+            modifier
+                .padding(vertical = verticalPadding)
+                .run {
+                    if (border != null) {
+                        border(border = border, shape = shape)
+                    } else {
+                        this
+                    }
+                }.clip(shape)
+                .background(background)
+                .clickable(enabled = enabled, onClick = onClick)
+                .defaultMinSize(minHeight = minHeight),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingIcon != null) {
+            Icon(
+                painter = leadingIcon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = contentColor,
+            )
+            if (text.isNotEmpty()) Spacer(Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            color = contentColor,
+            style = if (enabled) FlintTheme.typography.body1Sb16 else FlintTheme.typography.body1M16,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FlintButtonPreview() {
+    FlintTheme {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            FlintButton(
+                text = "시작하기",
+                type = FlintButtonType.Large,
+                state = FlintButtonState.Able,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FlintButton(
+                text = "시작하기",
+                type = FlintButtonType.Large,
+                state = FlintButtonState.Disable,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FlintButton(
+                text = "시작하기",
+                type = FlintButtonType.Large,
+                state = FlintButtonState.ColorOutline,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FlintButton(
+                text = "시작하기",
+                type = FlintButtonType.Large,
+                state = FlintButtonState.Outline,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Row {
+                FlintButton(
+                    text = "시작하기",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.Able,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                FlintButton(
+                    text = "시작하기",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.Outline,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Row {
+                FlintButton(
+                    text = "시작하기",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.Disable,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(16.dp))
+
+                FlintButton(
+                    text = "시작하기",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.ColorOutline,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Row {
+                FlintButton(
+                    text = "공개",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.Disable,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    leadingIcon = painterResource(R.drawable.ic_share),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                FlintButton(
+                    text = "공개",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.ColorOutline,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    leadingIcon = painterResource(R.drawable.ic_share),
+                )
+            }
+
+            Row {
+                FlintButton(
+                    text = "공개",
+                    type = FlintButtonType.Medium,
+                    state = FlintButtonState.Outline,
+                    onClick = {},
+                    modifier = Modifier.weight(0.5f),
+                    leadingIcon = painterResource(R.drawable.ic_share),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                Spacer(Modifier.weight(0.5f))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/FlintButton.kt
@@ -120,8 +120,10 @@ fun FlintButton(
                 modifier = Modifier.size(24.dp),
                 tint = contentColor,
             )
+
             if (text.isNotEmpty()) Spacer(Modifier.width(8.dp))
         }
+
         Text(
             text = text,
             color = contentColor,
@@ -201,6 +203,7 @@ private fun FlintButtonPreview() {
                     onClick = {},
                     modifier = Modifier.weight(1f),
                 )
+
                 Spacer(Modifier.width(16.dp))
 
                 FlintButton(

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.flint.R
 import com.flint.core.designsystem.theme.FlintTheme
@@ -35,8 +34,6 @@ fun FlintBasicButton(
     text: String,
     state: FlintButtonState,
     onClick: () -> Unit,
-    verticalPadding: Dp,
-    minHeight: Dp,
     modifier: Modifier = Modifier,
     @DrawableRes leadingIconRes: Int? = null,
 ) {
@@ -49,7 +46,6 @@ fun FlintBasicButton(
     Row(
         modifier =
             modifier
-                .padding(vertical = verticalPadding)
                 .run {
                     if (border != null) {
                         border(border = border, shape = shape)
@@ -58,8 +54,7 @@ fun FlintBasicButton(
                     }
                 }.clip(shape)
                 .background(background)
-                .clickable(enabled = enabled, onClick = onClick)
-                .defaultMinSize(minHeight = minHeight),
+                .clickable(enabled = enabled, onClick = onClick),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -97,36 +92,44 @@ private fun FlintBasicButtonPreview() {
                 text = "시작하기",
                 state = FlintButtonState.Able,
                 onClick = {},
-                verticalPadding = 0.dp,
-                minHeight = 48.dp,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .defaultMinSize(minHeight = 48.dp)
+                        .padding(vertical = 0.dp),
             )
 
             FlintBasicButton(
                 text = "시작하기",
                 state = FlintButtonState.Disable,
                 onClick = {},
-                verticalPadding = 0.dp,
-                minHeight = 48.dp,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .defaultMinSize(minHeight = 48.dp)
+                        .padding(vertical = 0.dp),
             )
 
             FlintBasicButton(
                 text = "시작하기",
                 state = FlintButtonState.ColorOutline,
                 onClick = {},
-                verticalPadding = 0.dp,
-                minHeight = 48.dp,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .defaultMinSize(minHeight = 48.dp)
+                        .padding(vertical = 0.dp),
             )
 
             FlintBasicButton(
                 text = "시작하기",
                 state = FlintButtonState.Outline,
                 onClick = {},
-                verticalPadding = 0.dp,
-                minHeight = 48.dp,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .defaultMinSize(minHeight = 48.dp)
+                        .padding(vertical = 0.dp),
             )
 
             Row {
@@ -134,9 +137,11 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.Able,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))
@@ -145,9 +150,11 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.Outline,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
             }
 
@@ -156,9 +163,11 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.Disable,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))
@@ -167,9 +176,11 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
             }
 
@@ -178,10 +189,12 @@ private fun FlintBasicButtonPreview() {
                     text = "공개",
                     state = FlintButtonState.Disable,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
                     leadingIconRes = R.drawable.ic_share,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))
@@ -190,10 +203,12 @@ private fun FlintBasicButtonPreview() {
                     text = "공개",
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
                     leadingIconRes = R.drawable.ic_share,
-                    modifier = Modifier.weight(1f),
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
             }
 
@@ -202,10 +217,12 @@ private fun FlintBasicButtonPreview() {
                     text = "공개",
                     state = FlintButtonState.Outline,
                     onClick = {},
-                    verticalPadding = 2.dp,
-                    minHeight = 44.dp,
                     leadingIconRes = R.drawable.ic_share,
-                    modifier = Modifier.weight(0.5f),
+                    modifier =
+                        Modifier
+                            .weight(0.5f)
+                            .defaultMinSize(minHeight = 44.dp)
+                            .padding(vertical = 2.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -35,6 +36,7 @@ fun FlintBasicButton(
     state: FlintButtonState,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues,
     @DrawableRes leadingIconRes: Int? = null,
 ) {
     val enabled: Boolean = state.enabled
@@ -55,7 +57,7 @@ fun FlintBasicButton(
                 }.clip(shape)
                 .background(background)
                 .clickable(enabled = enabled, onClick = onClick)
-                .padding(10.dp),
+                .padding(contentPadding),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -93,6 +95,7 @@ private fun FlintBasicButtonPreview() {
                 text = "시작하기",
                 state = FlintButtonState.Able,
                 onClick = {},
+                contentPadding = PaddingValues(12.dp),
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -104,6 +107,7 @@ private fun FlintBasicButtonPreview() {
                 text = "시작하기",
                 state = FlintButtonState.Disable,
                 onClick = {},
+                contentPadding = PaddingValues(12.dp),
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -115,6 +119,7 @@ private fun FlintBasicButtonPreview() {
                 text = "시작하기",
                 state = FlintButtonState.ColorOutline,
                 onClick = {},
+                contentPadding = PaddingValues(12.dp),
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -126,6 +131,7 @@ private fun FlintBasicButtonPreview() {
                 text = "시작하기",
                 state = FlintButtonState.Outline,
                 onClick = {},
+                contentPadding = PaddingValues(12.dp),
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -138,6 +144,7 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.Able,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     modifier =
                         Modifier
                             .weight(1f)
@@ -151,6 +158,7 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.Outline,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     modifier =
                         Modifier
                             .weight(1f)
@@ -164,6 +172,7 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.Disable,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     modifier =
                         Modifier
                             .weight(1f)
@@ -177,6 +186,7 @@ private fun FlintBasicButtonPreview() {
                     text = "시작하기",
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     modifier =
                         Modifier
                             .weight(1f)
@@ -190,6 +200,7 @@ private fun FlintBasicButtonPreview() {
                     text = "공개",
                     state = FlintButtonState.Disable,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     leadingIconRes = R.drawable.ic_share,
                     modifier =
                         Modifier
@@ -204,6 +215,7 @@ private fun FlintBasicButtonPreview() {
                     text = "공개",
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     leadingIconRes = R.drawable.ic_share,
                     modifier =
                         Modifier
@@ -218,6 +230,7 @@ private fun FlintBasicButtonPreview() {
                     text = "공개",
                     state = FlintButtonState.Outline,
                     onClick = {},
+                    contentPadding = PaddingValues(10.dp),
                     leadingIconRes = R.drawable.ic_share,
                     modifier =
                         Modifier

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
@@ -54,7 +54,8 @@ fun FlintBasicButton(
                     }
                 }.clip(shape)
                 .background(background)
-                .clickable(enabled = enabled, onClick = onClick),
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(10.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
@@ -1,5 +1,6 @@
-package com.flint.core.designsystem.component
+package com.flint.core.designsystem.component.button
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -17,14 +18,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -32,82 +30,16 @@ import androidx.compose.ui.unit.dp
 import com.flint.R
 import com.flint.core.designsystem.theme.FlintTheme
 
-sealed interface FlintButtonType {
-    val verticalPadding: Dp
-    val minHeight: Dp
-
-    object Large : FlintButtonType {
-        override val verticalPadding = 0.dp
-        override val minHeight = 48.dp
-    }
-
-    object Medium : FlintButtonType {
-        override val verticalPadding = 2.dp
-        override val minHeight = 44.dp
-    }
-
-    class Icon(
-        val icon: Painter,
-    ) : FlintButtonType {
-        override val verticalPadding = 2.dp
-        override val minHeight = 44.dp
-    }
-}
-
-enum class FlintButtonState(
-    val enabled: Boolean,
-) {
-    Able(enabled = true),
-    Disable(enabled = false),
-    Outline(enabled = true),
-    ColorOutline(enabled = true),
-    ;
-
-    val background: Brush
-        @Composable
-        @ReadOnlyComposable
-        get() =
-            when (this) {
-                Able -> FlintTheme.colors.gradient400
-                Disable -> SolidColor(FlintTheme.colors.gray700)
-                Outline, ColorOutline -> SolidColor(FlintTheme.colors.gray800)
-            }
-
-    val contentColor: Color
-        @Composable
-        @ReadOnlyComposable
-        get() =
-            when (this) {
-                Able, Outline, ColorOutline -> FlintTheme.colors.white
-                Disable -> FlintTheme.colors.gray400
-            }
-
-    val border: BorderStroke?
-        @Composable
-        @ReadOnlyComposable
-        get() =
-            when (this) {
-                Outline -> BorderStroke(2.dp, FlintTheme.colors.gray500)
-                ColorOutline -> BorderStroke(2.dp, FlintTheme.colors.primary400)
-                else -> null
-            }
-}
-
 @Composable
-fun FlintButton(
+fun FlintBasicButton(
     text: String,
-    type: FlintButtonType,
     state: FlintButtonState,
     onClick: () -> Unit,
+    verticalPadding: Dp,
+    minHeight: Dp,
     modifier: Modifier = Modifier,
+    @DrawableRes leadingIconRes: Int? = null,
 ) {
-    val verticalPadding: Dp = type.verticalPadding
-    val minHeight: Dp = type.minHeight
-    val leadingIcon: Painter? =
-        when (type) {
-            is FlintButtonType.Icon -> type.icon
-            else -> null
-        }
     val enabled: Boolean = state.enabled
     val background: Brush = state.background
     val contentColor: Color = state.contentColor
@@ -131,9 +63,9 @@ fun FlintButton(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (leadingIcon != null) {
+        if (leadingIconRes != null) {
             Icon(
-                painter = leadingIcon,
+                painter = painterResource(leadingIconRes),
                 contentDescription = null,
                 modifier = Modifier.size(24.dp),
                 tint = contentColor,
@@ -152,7 +84,7 @@ fun FlintButton(
 
 @Preview
 @Composable
-private fun FlintButtonPreview() {
+private fun FlintBasicButtonPreview() {
     FlintTheme {
         Column(
             modifier =
@@ -161,104 +93,118 @@ private fun FlintButtonPreview() {
                     .padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            FlintButton(
+            FlintBasicButton(
                 text = "시작하기",
-                type = FlintButtonType.Large,
                 state = FlintButtonState.Able,
                 onClick = {},
+                verticalPadding = 0.dp,
+                minHeight = 48.dp,
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            FlintButton(
+            FlintBasicButton(
                 text = "시작하기",
-                type = FlintButtonType.Large,
                 state = FlintButtonState.Disable,
                 onClick = {},
+                verticalPadding = 0.dp,
+                minHeight = 48.dp,
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            FlintButton(
+            FlintBasicButton(
                 text = "시작하기",
-                type = FlintButtonType.Large,
                 state = FlintButtonState.ColorOutline,
                 onClick = {},
+                verticalPadding = 0.dp,
+                minHeight = 48.dp,
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            FlintButton(
+            FlintBasicButton(
                 text = "시작하기",
-                type = FlintButtonType.Large,
                 state = FlintButtonState.Outline,
                 onClick = {},
+                verticalPadding = 0.dp,
+                minHeight = 48.dp,
                 modifier = Modifier.fillMaxWidth(),
             )
 
             Row {
-                FlintButton(
+                FlintBasicButton(
                     text = "시작하기",
-                    type = FlintButtonType.Medium,
                     state = FlintButtonState.Able,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
                     modifier = Modifier.weight(1f),
                 )
 
                 Spacer(Modifier.width(16.dp))
 
-                FlintButton(
+                FlintBasicButton(
                     text = "시작하기",
-                    type = FlintButtonType.Medium,
                     state = FlintButtonState.Outline,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
                     modifier = Modifier.weight(1f),
                 )
             }
 
             Row {
-                FlintButton(
+                FlintBasicButton(
                     text = "시작하기",
-                    type = FlintButtonType.Medium,
                     state = FlintButtonState.Disable,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
                     modifier = Modifier.weight(1f),
                 )
 
                 Spacer(Modifier.width(16.dp))
 
-                FlintButton(
+                FlintBasicButton(
                     text = "시작하기",
-                    type = FlintButtonType.Medium,
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
                     modifier = Modifier.weight(1f),
                 )
             }
 
             Row {
-                FlintButton(
+                FlintBasicButton(
                     text = "공개",
-                    type = FlintButtonType.Icon(painterResource(R.drawable.ic_share)),
                     state = FlintButtonState.Disable,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
+                    leadingIconRes = R.drawable.ic_share,
                     modifier = Modifier.weight(1f),
                 )
 
                 Spacer(Modifier.width(16.dp))
 
-                FlintButton(
+                FlintBasicButton(
                     text = "공개",
-                    type = FlintButtonType.Icon(painterResource(R.drawable.ic_share)),
                     state = FlintButtonState.ColorOutline,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
+                    leadingIconRes = R.drawable.ic_share,
                     modifier = Modifier.weight(1f),
                 )
             }
 
             Row {
-                FlintButton(
+                FlintBasicButton(
                     text = "공개",
-                    type = FlintButtonType.Icon(painterResource(R.drawable.ic_share)),
                     state = FlintButtonState.Outline,
                     onClick = {},
+                    verticalPadding = 2.dp,
+                    minHeight = 44.dp,
+                    leadingIconRes = R.drawable.ic_share,
                     modifier = Modifier.weight(0.5f),
                 )
 

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
@@ -95,8 +95,8 @@ private fun FlintBasicButtonPreview() {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .defaultMinSize(minHeight = 48.dp)
-                        .padding(vertical = 0.dp),
+                        .padding(vertical = 0.dp)
+                        .defaultMinSize(minHeight = 48.dp),
             )
 
             FlintBasicButton(
@@ -106,8 +106,8 @@ private fun FlintBasicButtonPreview() {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .defaultMinSize(minHeight = 48.dp)
-                        .padding(vertical = 0.dp),
+                        .padding(vertical = 0.dp)
+                        .defaultMinSize(minHeight = 48.dp),
             )
 
             FlintBasicButton(
@@ -117,8 +117,8 @@ private fun FlintBasicButtonPreview() {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .defaultMinSize(minHeight = 48.dp)
-                        .padding(vertical = 0.dp),
+                        .padding(vertical = 0.dp)
+                        .defaultMinSize(minHeight = 48.dp),
             )
 
             FlintBasicButton(
@@ -128,8 +128,8 @@ private fun FlintBasicButtonPreview() {
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .defaultMinSize(minHeight = 48.dp)
-                        .padding(vertical = 0.dp),
+                        .padding(vertical = 0.dp)
+                        .defaultMinSize(minHeight = 48.dp),
             )
 
             Row {
@@ -140,8 +140,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))
@@ -153,8 +153,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
             }
 
@@ -166,8 +166,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))
@@ -179,8 +179,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
             }
 
@@ -193,8 +193,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))
@@ -207,8 +207,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
             }
 
@@ -221,8 +221,8 @@ private fun FlintBasicButtonPreview() {
                     modifier =
                         Modifier
                             .weight(0.5f)
-                            .defaultMinSize(minHeight = 44.dp)
-                            .padding(vertical = 2.dp),
+                            .padding(vertical = 2.dp)
+                            .defaultMinSize(minHeight = 44.dp),
                 )
 
                 Spacer(Modifier.width(16.dp))

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintButtonState.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintButtonState.kt
@@ -1,0 +1,98 @@
+package com.flint.core.designsystem.component.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.theme.FlintTheme
+
+enum class FlintButtonState(
+    val enabled: Boolean,
+) {
+    Able(enabled = true) {
+        override val background: Brush
+            @Composable
+            @ReadOnlyComposable
+            get() = FlintTheme.colors.gradient400
+
+        override val contentColor: Color
+            @Composable
+            @ReadOnlyComposable
+            get() = FlintTheme.colors.white
+
+        override val border: BorderStroke?
+            @Composable
+            @ReadOnlyComposable
+            get() = null
+    },
+
+    Disable(enabled = false) {
+        override val background: Brush
+            @Composable
+            @ReadOnlyComposable
+            get() = SolidColor(FlintTheme.colors.gray700)
+
+        override val contentColor: Color
+            @Composable
+            @ReadOnlyComposable
+            get() = FlintTheme.colors.gray400
+
+        override val border: BorderStroke?
+            @Composable
+            @ReadOnlyComposable
+            get() = null
+    },
+
+    Outline(enabled = true) {
+        override val background: Brush
+            @Composable
+            @ReadOnlyComposable
+            get() = SolidColor(FlintTheme.colors.gray800)
+
+        override val contentColor: Color
+            @Composable
+            @ReadOnlyComposable
+            get() = FlintTheme.colors.white
+
+        override val border: BorderStroke
+            @Composable
+            @ReadOnlyComposable
+            get() = BorderStroke(2.dp, FlintTheme.colors.gray500)
+    },
+
+    ColorOutline(enabled = true) {
+        override val background: Brush
+            @Composable
+            @ReadOnlyComposable
+            get() = SolidColor(FlintTheme.colors.gray800)
+
+        override val contentColor: Color
+            @Composable
+            @ReadOnlyComposable
+            get() = FlintTheme.colors.white
+
+        override val border: BorderStroke
+            @Composable
+            @ReadOnlyComposable
+            get() = BorderStroke(2.dp, FlintTheme.colors.primary400)
+    },
+    ;
+
+    abstract val background: Brush
+        @Composable
+        @ReadOnlyComposable
+        get
+
+    abstract val contentColor: Color
+        @Composable
+        @ReadOnlyComposable
+        get
+
+    abstract val border: BorderStroke?
+        @Composable
+        @ReadOnlyComposable
+        get
+}

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintIconButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintIconButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -27,10 +28,11 @@ fun FlintIconButton(
         text = text,
         state = state,
         onClick = onClick,
-        verticalPadding = 2.dp,
-        minHeight = 44.dp,
         leadingIconRes = iconRes,
-        modifier = modifier,
+        modifier =
+            modifier
+                .padding(vertical = 2.dp)
+                .defaultMinSize(minHeight = 44.dp),
     )
 }
 

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintIconButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintIconButton.kt
@@ -1,0 +1,83 @@
+package com.flint.core.designsystem.component.button
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun FlintIconButton(
+    text: String,
+    @DrawableRes iconRes: Int,
+    state: FlintButtonState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlintBasicButton(
+        text = text,
+        state = state,
+        onClick = onClick,
+        verticalPadding = 2.dp,
+        minHeight = 44.dp,
+        leadingIconRes = iconRes,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun FlintIconButtonPreview() {
+    FlintTheme {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Row {
+                FlintIconButton(
+                    text = "공개",
+                    iconRes = R.drawable.ic_share,
+                    state = FlintButtonState.Disable,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                FlintIconButton(
+                    text = "공개",
+                    iconRes = R.drawable.ic_share,
+                    state = FlintButtonState.ColorOutline,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Row {
+                FlintIconButton(
+                    text = "공개",
+                    iconRes = R.drawable.ic_share,
+                    state = FlintButtonState.Outline,
+                    onClick = {},
+                    modifier = Modifier.weight(0.5f),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                Spacer(Modifier.weight(0.5f))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintIconButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintIconButton.kt
@@ -3,6 +3,7 @@ package com.flint.core.designsystem.component.button
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -29,6 +30,7 @@ fun FlintIconButton(
         state = state,
         onClick = onClick,
         leadingIconRes = iconRes,
+        contentPadding = PaddingValues(10.dp),
         modifier =
             modifier
                 .padding(vertical = 2.dp)

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintLargeButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintLargeButton.kt
@@ -2,6 +2,7 @@ package com.flint.core.designsystem.component.button
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,6 +23,7 @@ fun FlintLargeButton(
         text = text,
         state = state,
         onClick = onClick,
+        contentPadding = PaddingValues(12.dp),
         modifier =
             modifier
                 .padding(vertical = 0.dp)

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintLargeButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintLargeButton.kt
@@ -1,0 +1,70 @@
+package com.flint.core.designsystem.component.button
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun FlintLargeButton(
+    text: String,
+    state: FlintButtonState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlintBasicButton(
+        text = text,
+        state = state,
+        onClick = onClick,
+        verticalPadding = 0.dp,
+        minHeight = 48.dp,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun FlintLargeButtonPreview() {
+    FlintTheme {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            FlintLargeButton(
+                text = "시작하기",
+                state = FlintButtonState.Able,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FlintLargeButton(
+                text = "시작하기",
+                state = FlintButtonState.Disable,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FlintLargeButton(
+                text = "시작하기",
+                state = FlintButtonState.ColorOutline,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FlintLargeButton(
+                text = "시작하기",
+                state = FlintButtonState.Outline,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintLargeButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintLargeButton.kt
@@ -2,6 +2,7 @@ package com.flint.core.designsystem.component.button
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -21,9 +22,10 @@ fun FlintLargeButton(
         text = text,
         state = state,
         onClick = onClick,
-        verticalPadding = 0.dp,
-        minHeight = 48.dp,
-        modifier = modifier,
+        modifier =
+            modifier
+                .padding(vertical = 0.dp)
+                .defaultMinSize(minHeight = 48.dp),
     )
 }
 

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintMediumButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintMediumButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -24,9 +25,10 @@ fun FlintMediumButton(
         text = text,
         state = state,
         onClick = onClick,
-        verticalPadding = 2.dp,
-        minHeight = 44.dp,
-        modifier = modifier,
+        modifier =
+            modifier
+                .padding(vertical = 2.dp)
+                .defaultMinSize(minHeight = 44.dp),
     )
 }
 

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintMediumButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintMediumButton.kt
@@ -2,6 +2,7 @@ package com.flint.core.designsystem.component.button
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -25,6 +26,7 @@ fun FlintMediumButton(
         text = text,
         state = state,
         onClick = onClick,
+        contentPadding = PaddingValues(10.dp),
         modifier =
             modifier
                 .padding(vertical = 2.dp)

--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintMediumButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintMediumButton.kt
@@ -1,0 +1,81 @@
+package com.flint.core.designsystem.component.button
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun FlintMediumButton(
+    text: String,
+    state: FlintButtonState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlintBasicButton(
+        text = text,
+        state = state,
+        onClick = onClick,
+        verticalPadding = 2.dp,
+        minHeight = 44.dp,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun FlintMediumButtonPreview() {
+    FlintTheme {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Row {
+                FlintMediumButton(
+                    text = "시작하기",
+                    state = FlintButtonState.Able,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                FlintMediumButton(
+                    text = "시작하기",
+                    state = FlintButtonState.Outline,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Row {
+                FlintMediumButton(
+                    text = "시작하기",
+                    state = FlintButtonState.Disable,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                FlintMediumButton(
+                    text = "시작하기",
+                    state = FlintButtonState.ColorOutline,
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📮 관련 이슈
- closed #16 

## 📌 작업 내용
- 앱에서 사용될 Button 공통 컴포넌트를 구현하였습니다.

## 📸 스크린샷
| Preview | 글자 크게 | 글자 작게 |
|:--:|:--:|:--:| 
| <img width="521" height="772" alt="FlintButtons" src="https://github.com/user-attachments/assets/d0a0740f-2537-4a97-af52-64d3a6d14cb0" /> | <img width="521" height="772" alt="FlintButtons" src="https://github.com/user-attachments/assets/0323dcba-3061-4fcc-997c-69e3df91b213" /> | <img width="521" height="772" alt="FlintButtons" src="https://github.com/user-attachments/assets/405a7597-94e8-475a-af49-9c5fe7a80ebd" />|

## 😅 미구현
- [ ] 아이콘 버튼의 경우 `text` 길이에 관계없이 아이콘을 일정한 위치에 둔다는 디자인 요구사항이 있습니다.

## 🫛 To. 리뷰어
- 위 미구현 사항 관련해서는 디자이너분과 소통이 필요할 것 같아요. https://github.com/imflint/Flint-Android/issues/22 에서 따로 작업하도록 하겠습니다.
