### PR TITLE
[Feat] 색 spoiler_blur 추가 대응

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/flint/core/designsystem/theme/Color.kt
@@ -54,6 +54,7 @@ data class Colors(
     val error500: Color,
     val error700: Color,
     val overlay: Color,
+    val spoilerBlur: Color,
     val gradient900: Brush,
     val gradient700: Brush,
     val gradient400: Brush,
@@ -98,6 +99,7 @@ val FlintColors =
         error500 = Color(0xFFFF4D62),
         error700 = Color(0xFFB53746),
         overlay = Color(0xFF000000).copy(alpha = 0.6f),
+        spoilerBlur = Color(0xFF121212).copy(alpha = 0.3f),
         gradient900 =
         Brush.linearGradient(
             colors = listOf(Color(0xFF3C4256), Color(0xFF121212))
@@ -111,9 +113,9 @@ val FlintColors =
             colors = listOf(Color(0xFF1ABFF2), Color(0xFF86EBFF))
         ),
         imgBlur =
-        Brush.linearGradient(
-            colors = listOf(Color(0xFF000000).copy(alpha = 0.8f), Color(0xFF000000))
-        )
+            Brush.linearGradient(
+                colors = listOf(Color(0xFF000000).copy(alpha = 0.8f), Color(0xFF000000).copy(0f)),
+            ),
     )
 
 @Preview(device = Devices.DESKTOP)
@@ -132,23 +134,23 @@ private fun FlintColorsPreview() {
             )
             Box(
                 Modifier
+                    .background(color = FlintColors.primary100)
+                    .size(100.dp),
+            )
+            Box(
+                Modifier
                     .background(color = FlintColors.primary200)
-                    .size(100.dp)
+                    .size(100.dp),
             )
             Box(
                 Modifier
                     .background(color = FlintColors.primary300)
-                    .size(100.dp)
+                    .size(100.dp),
             )
             Box(
                 Modifier
                     .background(color = FlintColors.primary400)
-                    .size(100.dp)
-            )
-            Box(
-                Modifier
-                    .background(color = FlintColors.primary100)
-                    .size(100.dp)
+                    .size(100.dp),
             )
             Box(
                 Modifier
@@ -314,6 +316,15 @@ private fun FlintColorsPreview() {
                     .background(color = FlintColors.overlay)
                     .size(100.dp)
             )
+            Box(
+                Modifier
+                    .background(color = FlintColors.spoilerBlur)
+                    .size(100.dp),
+            )
+        }
+
+        Text("Gradient", color = Color.White)
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             Box(
                 Modifier
                     .background(brush = FlintColors.gradient900)


### PR DESCRIPTION
## 📮 관련 이슈
- closed #23 

## 📌 작업 내용
- 새로 추가된 색 `spoiler_blur`를 디자인 시스템에 추가했습니다.
- 추가적으로 색상 설정이 잘못된 imgBlur를 수정했습니다.
- Preview에 순서가 잘못된 부분이 있어 이를 수정했습니다.

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <img width="834" height="544" alt="flint colors preview" src="https://github.com/user-attachments/assets/d25a01ee-3411-4dfb-b4ce-7f0a8e755a49" /> |
