### PR TITLE
[Feat/#9] TextField 공통 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
@@ -40,6 +40,7 @@ fun FlintBasicTextField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     maxLines: Int = 1,
+    maxLength: Int = Int.MAX_VALUE,
     height: Dp = 40.dp,
     radius: Dp = 8.dp,
     textStyle: TextStyle = FlintTheme.typography.body1R16,
@@ -68,7 +69,11 @@ fun FlintBasicTextField(
             modifier = Modifier.fillMaxSize(),
             value = value,
             textStyle = textStyle.copy(color = FlintTheme.colors.white),
-            onValueChange = onValueChange,
+            onValueChange = {
+                if (it.length <= maxLength) { // TODO: 글자수 제한 정책 기획 확인 필요
+                    onValueChange(it)
+                }
+            },
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             visualTransformation = visualTransformation,
@@ -130,6 +135,7 @@ private fun FlintTextFieldCounterPreview() {
             modifier = Modifier.fillMaxWidth(),
             placeholder = "닉네임",
             value = text,
+            maxLength = 20,
             onValueChange = { text = it },
             trailingContent = {
                 Text(

--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
@@ -1,18 +1,16 @@
 package com.flint.core.designsystem.component.textfield
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -26,15 +24,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.flint.R
 import com.flint.core.designsystem.theme.FlintTheme
 
 @Composable
@@ -46,8 +42,10 @@ fun FlintBasicTextField(
     maxLines: Int = 1,
     height: Dp = 40.dp,
     radius: Dp = 8.dp,
-    paddingValues: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     textStyle: TextStyle = FlintTheme.typography.body1R16,
+    backgroundColor: Color = FlintTheme.colors.gray800,
+    borderColor: Color = Color.Unspecified,
+    paddingValues: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -59,7 +57,12 @@ fun FlintBasicTextField(
         modifier = modifier
             .height(height)
             .clip(RoundedCornerShape(radius))
-            .background(FlintTheme.colors.gray800)
+            .background(backgroundColor)
+            .border(
+                width = 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(radius)
+            )
     ) {
         BasicTextField(
             modifier = Modifier.fillMaxSize(),
@@ -133,62 +136,6 @@ private fun FlintTextFieldCounterPreview() {
                     text = "${text.length}/20",
                     style = FlintTheme.typography.body2R14,
                     color = FlintTheme.colors.gray300
-                )
-            }
-        )
-    }
-}
-
-@Preview(showBackground = false)
-@Composable
-private fun FlintTextFieldMultiLineWithLengthPreview() {
-    FlintTheme {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.End
-        ) {
-            var text by remember { mutableStateOf("") }
-
-            FlintBasicTextField(
-                modifier = Modifier.fillMaxWidth(),
-                placeholder = "컬렉션의 주제를 작성해주세요.",
-                value = text,
-                onValueChange = { text = it },
-                height = 120.dp,
-                maxLines = 5
-            )
-
-            Text(
-                text = "${text.length}/200",
-                style = FlintTheme.typography.caption1M12,
-                color = FlintTheme.colors.white
-            )
-        }
-    }
-}
-
-@Preview(showBackground = false)
-@Composable
-private fun FlintSearchTextFieldPreview() {
-    FlintTheme {
-        var text by remember { mutableStateOf("") }
-
-        FlintBasicTextField(
-            modifier = Modifier.fillMaxWidth(),
-            placeholder = "작품 이름",
-            value = text,
-            onValueChange = { text = it },
-            radius = 36.dp,
-            height = 44.dp,
-            maxLines = 1,
-            paddingValues = PaddingValues(start = 16.dp),
-            trailingContent = {
-                Image(
-                    modifier = Modifier
-                        .padding(12.dp)
-                        .size(24.dp),
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_search),
-                    contentDescription = null
                 )
             }
         )

--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
@@ -1,0 +1,106 @@
+package com.flint.core.designsystem.component.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun FlintBasicTextField(
+    placeholder: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    maxLines: Int = 1,
+    height: Dp = 40.dp,
+    radius: Dp = 8.dp,
+    trailingContent: @Composable () -> Unit = {},
+    textStyle: TextStyle = FlintTheme.typography.body1R16,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None
+) {
+    val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .height(height)
+            .clip(RoundedCornerShape(radius))
+            .background(FlintTheme.colors.gray800)
+    ) {
+        BasicTextField(
+            modifier = Modifier.fillMaxSize(),
+            value = value,
+            textStyle = textStyle.copy(color = FlintTheme.colors.white),
+            onValueChange = onValueChange,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            visualTransformation = visualTransformation,
+            interactionSource = interactionSource,
+            maxLines = maxLines,
+            decorationBox = { innerTextField ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        if (value.isEmpty()) { // PlaceHolder
+                            Text(
+                                text = placeholder,
+                                style = textStyle,
+                                color = FlintTheme.colors.gray300
+                            )
+                        }
+                        innerTextField()
+                    }
+                    trailingContent()
+                }
+            }
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun BasicTextFieldPreview() {
+    FlintTheme {
+        var text by remember { mutableStateOf("") }
+
+        FlintBasicTextField(
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = "PlaceHolder",
+            value = text,
+            onValueChange = { text = it },
+            trailingContent = {},
+        )
+    }
+}

--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintBasicTextField.kt
@@ -1,14 +1,18 @@
 package com.flint.core.designsystem.component.textfield
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -22,11 +26,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.flint.R
 import com.flint.core.designsystem.theme.FlintTheme
 
 @Composable
@@ -38,11 +46,12 @@ fun FlintBasicTextField(
     maxLines: Int = 1,
     height: Dp = 40.dp,
     radius: Dp = 8.dp,
-    trailingContent: @Composable () -> Unit = {},
+    paddingValues: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     textStyle: TextStyle = FlintTheme.typography.body1R16,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
-    visualTransformation: VisualTransformation = VisualTransformation.None
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    trailingContent: @Composable () -> Unit = {}
 ) {
     val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 
@@ -62,16 +71,20 @@ fun FlintBasicTextField(
             visualTransformation = visualTransformation,
             interactionSource = interactionSource,
             maxLines = maxLines,
+            cursorBrush = SolidColor(FlintTheme.colors.gray300),
             decorationBox = { innerTextField ->
                 Row(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                        .padding(paddingValues),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Box(
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .weight(1f),
+                        contentAlignment = if (maxLines == 1) Alignment.CenterStart else Alignment.TopStart
                     ) {
                         if (value.isEmpty()) { // PlaceHolder
                             Text(
@@ -99,8 +112,85 @@ private fun BasicTextFieldPreview() {
             modifier = Modifier.fillMaxWidth(),
             placeholder = "PlaceHolder",
             value = text,
+            onValueChange = { text = it }
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun FlintTextFieldCounterPreview() {
+    FlintTheme {
+        var text by remember { mutableStateOf("") }
+
+        FlintBasicTextField(
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = "닉네임",
+            value = text,
             onValueChange = { text = it },
-            trailingContent = {},
+            trailingContent = {
+                Text(
+                    text = "${text.length}/20",
+                    style = FlintTheme.typography.body2R14,
+                    color = FlintTheme.colors.gray300
+                )
+            }
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun FlintTextFieldMultiLineWithLengthPreview() {
+    FlintTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.End
+        ) {
+            var text by remember { mutableStateOf("") }
+
+            FlintBasicTextField(
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = "컬렉션의 주제를 작성해주세요.",
+                value = text,
+                onValueChange = { text = it },
+                height = 120.dp,
+                maxLines = 5
+            )
+
+            Text(
+                text = "${text.length}/200",
+                style = FlintTheme.typography.caption1M12,
+                color = FlintTheme.colors.white
+            )
+        }
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun FlintSearchTextFieldPreview() {
+    FlintTheme {
+        var text by remember { mutableStateOf("") }
+
+        FlintBasicTextField(
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = "작품 이름",
+            value = text,
+            onValueChange = { text = it },
+            radius = 36.dp,
+            height = 44.dp,
+            maxLines = 1,
+            paddingValues = PaddingValues(start = 16.dp),
+            trailingContent = {
+                Image(
+                    modifier = Modifier
+                        .padding(12.dp)
+                        .size(24.dp),
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_search),
+                    contentDescription = null
+                )
+            }
         )
     }
 }

--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintLongTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintLongTextField.kt
@@ -1,0 +1,63 @@
+package com.flint.core.designsystem.component.textfield
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun FlintLongTextField(
+    value: String,
+    onValueChanged: (String) -> Unit,
+    maxLength: Int,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    height: Dp = 120.dp
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.End
+    ) {
+        FlintBasicTextField(
+            modifier = modifier,
+            placeholder = placeholder,
+            value = value,
+            onValueChange = onValueChanged,
+            maxLines = 5,
+            height = height
+        )
+
+        Text(
+            text = "${value.length}/${maxLength}",
+            style = FlintTheme.typography.caption1M12,
+            color = FlintTheme.colors.white
+        )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun FlintLongTextFieldPreview() {
+    FlintTheme {
+        var text by remember { mutableStateOf("") }
+
+        FlintLongTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = text,
+            placeholder = "컬렉션의 주제를 작성해주세요.",
+            onValueChanged = { text = it },
+            maxLength = 200
+        )
+    }
+}

--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintSearchTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintSearchTextField.kt
@@ -1,0 +1,65 @@
+package com.flint.core.designsystem.component.textfield
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.common.extension.noRippleClickable
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun FlintSearchTextField(
+    value: String,
+    onValueChanged: (String) -> Unit,
+    placeholder: String,
+    onSearchAction: () -> Unit = {}
+) {
+    FlintBasicTextField(
+        modifier = Modifier.fillMaxWidth(),
+        placeholder = placeholder,
+        value = value,
+        onValueChange = onValueChanged,
+        radius = 36.dp,
+        height = 44.dp,
+        maxLines = 1,
+        paddingValues = PaddingValues(start = 16.dp),
+        trailingContent = {
+            Image(
+                modifier = Modifier
+                    .padding(12.dp)
+                    .size(24.dp)
+                    .noRippleClickable(
+                        onClick = { onSearchAction() }
+                    ),
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_search),
+                contentDescription = null
+            )
+        }
+    )
+}
+
+@Preview(showBackground = false)
+@Composable
+private fun FlintSearchTextFieldPreview() {
+    FlintTheme {
+        var text by remember { mutableStateOf("") }
+
+        FlintSearchTextField(
+            placeholder = "작품 이름",
+            value = text,
+            onValueChanged = { text = it }
+        )
+    }
+}


### PR DESCRIPTION
## 📮 관련 이슈
- closed #9

## 📌 작업 내용
- 기본 컴포넌트(`FlintBasicTextField`)랑, 한번 래핑해서 서치바(`FlintSearchTextField`)랑 컬렉션 생성 시에 쓰이는 거(`FlintLongTextField`) 구현했어요.

## 📸 스크린샷
| 컴포넌트 UI | 동작 모습 |
|:--:|:--:|
| <img width="561" height="527" alt="스크린샷 2026-01-10 오전 11 35 37" src="https://github.com/user-attachments/assets/d0e7bfc5-2372-4baa-b684-94969387a1bd" /> | <video width="300" src="https://github.com/user-attachments/assets/815645a1-5d0b-4d67-a689-3a1ddb49bda6" />

- 글자수 제한 및 입력 모습 확인하시라고 Preview Interaction 영상도 같이 넣어봐요!

## 😅 미구현
- [ ] `FlintLongTextField` 범용성 있게 바꾸기 (Short 버전도 호환하고 싶음)

## 🫛 To. 리뷰어
- `FlintLongTextField`(우측 하단에 글자수 있는 거)가 Short/Long을 같이 고려해야해서 수정이 필요할 것 같은데, 네이밍과 구현 방식이 좀 고민되네요. 코멘트 달아둘테니 같이 고민해주시면 감사하겠습니다!
- `FlintBasicTextField` Preview로 닉네임 입력용 컴포넌트를 예시로 넣어두긴 했는데, 닉네임 화면에서만 쓰이는 컴포넌트일 것 같아 제 작업범위는 아니라고 판단했습니다! 에러 처리 boder 설정 등등 추후에 화면 별 컴포넌트 작업 시에 조금 수정되어야할 부분이 있을 것 같은데, @ckals413 온보딩 담당자 확인 부탁드립니다!
