### PR TITLE
 [Feat/#27] .editorconfig 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+ktlint_function_naming_ignore_when_annotated_with = Composable


### PR DESCRIPTION
## 📮 관련 이슈
- closed #27 

## 📌 작업 내용
- `.editorconfig` 추가
  - EditorConfig는 여러 에디터/IDE에서 일관된 코드 스타일을 유지하기 위한 설정 파일입니다.
- Composable 함수가 Kotlin 함수 명명 규칙을 지키지 않아도 되도록 설정
  - Compose에서는 UI 컴포넌트 함수를 대문자로 시작하기 때문입니다.