### PR TITLE
[Feat] 온보딩 영화아이템 컴포넌트 추가

### DIFF
--- a/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
@@ -69,18 +69,15 @@ fun OnboardingFilmItem(
                         .fillMaxSize()
                         .background(FlintTheme.colors.overlay)
                 )
-            }
 
-            // 선택 시 체크 아이콘
-            if (isSelected) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_onboarding_film_check),
                     contentDescription = "선택됨",
                     tint = FlintTheme.colors.white,
                     modifier =
-                    Modifier
-                        .align(Alignment.Center)
-                        .size(48.dp)
+                        Modifier
+                            .align(Alignment.Center)
+                            .size(48.dp)
                 )
             }
         }

--- a/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
@@ -1,0 +1,155 @@
+package com.flint.presentation.onboarding.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.rememberAsyncImagePainter
+import com.flint.R
+import com.flint.core.designsystem.theme.FlintColors
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun OnboardingFilmItem(
+    imageUrl: String,
+    title: String,
+    director: String,
+    releaseYear: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.width(100.dp),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        // 영화 포스터 영역
+        Box(
+            modifier =
+                Modifier
+                    .aspectRatio(2f / 3f) // 영화 포스터 2:3 비율 유지
+                    .clip(RoundedCornerShape(0.dp))
+                    .clickable { onClick() },
+        ) {
+            // 영화 포스터 이미지
+            Image(
+                painter = rememberAsyncImagePainter(imageUrl),
+                contentDescription = title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            // 선택 시 어두운 오버레이
+            if (isSelected) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .background(FlintTheme.colors.overlay),
+                )
+            }
+
+            // 선택 시 체크 아이콘
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_onboarding_film_check),
+                    contentDescription = "선택됨",
+                    tint = FlintTheme.colors.white,
+                    modifier =
+                        Modifier
+                            .align(Alignment.Center)
+                            .size(48.dp),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // 영화 제목
+        Text(
+            text = title,
+            style = FlintTheme.typography.body1R16,
+            color = FlintTheme.colors.white,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis, // 넘치면 ...
+            modifier = Modifier.fillMaxWidth(),
+            )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // 감독 및 개봉일
+        Text(
+            text = director,
+            style = FlintTheme.typography.caption1R12,
+            color = FlintColors.gray300,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth(),
+            )
+
+        Text(
+            text = releaseYear,
+            style = FlintTheme.typography.caption1R12,
+            color = FlintColors.gray300,
+            maxLines = 1,
+            modifier = Modifier.fillMaxWidth(),
+            )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun OnboardingFilmItemSelectedPreview() {
+    FlintTheme {
+        Column(
+            modifier =
+                Modifier
+                    .background(FlintColors.background)
+                    .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            // 선택된 상태
+            OnboardingFilmItem(
+                imageUrl = "https://image.tmdb.org/t/p/w500/ulzhLuWrPK07PqYcvbBt2vWAbqB.jpg",
+                title = "김준서김나현임차민김종우박찬미",
+                director = "김준서김나현임차민김종우박찬미",
+                releaseYear = "2005",
+                isSelected = true,
+                onClick = {},
+            )
+
+            // 선택되지 않은 상태
+            OnboardingFilmItem(
+                imageUrl = "https://image.tmdb.org/t/p/w500/ulzhLuWrPK07PqYcvbBt2vWAbqB.jpg",
+                title = "김준서김나현",
+                director = "김준서김나현임차민김종우박찬미",
+                releaseYear = "2005",
+                isSelected = false,
+                onClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -40,35 +39,35 @@ fun OnboardingFilmItem(
     releaseYear: String,
     isSelected: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier.width(100.dp),
-        horizontalAlignment = Alignment.Start,
+        horizontalAlignment = Alignment.Start
     ) {
         // 영화 포스터 영역
         Box(
             modifier =
-                Modifier
-                    .aspectRatio(2f / 3f) // 영화 포스터 2:3 비율 유지
-                    .clip(RoundedCornerShape(0.dp))
-                    .clickable { onClick() },
+            Modifier
+                .aspectRatio(2f / 3f) // 영화 포스터 2:3 비율 유지
+                .clip(RoundedCornerShape(0.dp))
+                .clickable { onClick() }
         ) {
             // 영화 포스터 이미지
             Image(
                 painter = rememberAsyncImagePainter(imageUrl),
                 contentDescription = title,
                 contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize()
             )
 
             // 선택 시 어두운 오버레이
             if (isSelected) {
                 Box(
                     modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .background(FlintTheme.colors.overlay),
+                    Modifier
+                        .fillMaxSize()
+                        .background(FlintTheme.colors.overlay)
                 )
             }
 
@@ -79,9 +78,9 @@ fun OnboardingFilmItem(
                     contentDescription = "선택됨",
                     tint = FlintTheme.colors.white,
                     modifier =
-                        Modifier
-                            .align(Alignment.Center)
-                            .size(48.dp),
+                    Modifier
+                        .align(Alignment.Center)
+                        .size(48.dp)
                 )
             }
         }
@@ -95,8 +94,8 @@ fun OnboardingFilmItem(
             color = FlintTheme.colors.white,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis, // 넘치면 ...
-            modifier = Modifier.fillMaxWidth(),
-            )
+            modifier = Modifier.fillMaxWidth()
+        )
 
         Spacer(modifier = Modifier.height(4.dp))
 
@@ -107,16 +106,16 @@ fun OnboardingFilmItem(
             color = FlintColors.gray300,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(),
-            )
+            modifier = Modifier.fillMaxWidth()
+        )
 
         Text(
             text = releaseYear,
             style = FlintTheme.typography.caption1R12,
             color = FlintColors.gray300,
             maxLines = 1,
-            modifier = Modifier.fillMaxWidth(),
-            )
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -126,10 +125,10 @@ private fun OnboardingFilmItemSelectedPreview() {
     FlintTheme {
         Column(
             modifier =
-                Modifier
-                    .background(FlintColors.background)
-                    .padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
+            Modifier
+                .background(FlintColors.background)
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             // 선택된 상태
             OnboardingFilmItem(
@@ -138,7 +137,7 @@ private fun OnboardingFilmItemSelectedPreview() {
                 director = "김준서김나현임차민김종우박찬미",
                 releaseYear = "2005",
                 isSelected = true,
-                onClick = {},
+                onClick = {}
             )
 
             // 선택되지 않은 상태
@@ -148,7 +147,7 @@ private fun OnboardingFilmItemSelectedPreview() {
                 director = "김준서김나현임차민김종우박찬미",
                 releaseYear = "2005",
                 isSelected = false,
-                onClick = {},
+                onClick = {}
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingFilmItem.kt
@@ -75,9 +75,9 @@ fun OnboardingFilmItem(
                     contentDescription = "선택됨",
                     tint = FlintTheme.colors.white,
                     modifier =
-                        Modifier
-                            .align(Alignment.Center)
-                            .size(48.dp)
+                    Modifier
+                        .align(Alignment.Center)
+                        .size(48.dp)
                 )
             }
         }

--- a/app/src/main/res/drawable/ic_onboarding_film_check.xml
+++ b/app/src/main/res/drawable/ic_onboarding_film_check.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="37dp"
+    android:height="27dp"
+    android:viewportWidth="37"
+    android:viewportHeight="27">
+  <path
+      android:pathData="M35,2L12.313,25L2,14.545"
+      android:strokeLineJoin="round"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_onboarding_film_check.xml
+++ b/app/src/main/res/drawable/ic_onboarding_film_check.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="37dp"
-    android:height="27dp"
-    android:viewportWidth="37"
-    android:viewportHeight="27">
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
   <path
-      android:pathData="M35,2L12.313,25L2,14.545"
+      android:pathData="M36,8L14,32L4,21.091"
       android:strokeLineJoin="round"
       android:strokeWidth="4"
       android:fillColor="#00000000"


### PR DESCRIPTION
## 📮 관련 이슈
- closed #36 

## 📌 작업 내용
-  온보딩 영화아이템 컴포넌트 추가했습니다! 

## 📸 스크린샷
| 스크린샷 1 | 스크린샷(배경흰색) |
| :---: | :---: |
| <img width="140" alt="image" src="https://github.com/user-attachments/assets/12bc937d-b50f-4511-91c5-9a2f9cd05822" /> | <img width="140" alt="image" src="https://github.com/user-attachments/assets/038e9ad9-52a3-4176-9a09-8d922f0c966c" /> |


https://github.com/user-attachments/assets/e9ebb260-66ee-40db-a8ca-767d4bc9733b


## 🫛 To. 리뷰어
- 이미지를 
```Image(
                painter = rememberAsyncImagePainter(imageUrl),
                contentDescription = title,
                contentScale = ContentScale.Crop,
                modifier = Modifier.fillMaxSize(),
            )
``` 
이렇게 해둬 프리뷰에서 확인을 하지 못했습니다 !

