### PR TITLE
FlintBasicBottomSheet의 content 기본 패딩 제거

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/bottomsheet/FlintBasicBottomSheet.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/bottomsheet/FlintBasicBottomSheet.kt
@@ -69,10 +69,7 @@ fun FlintBasicBottomSheet(
             }
 
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp)
-                    .padding(bottom = 20.dp),
+                modifier = Modifier.fillMaxWidth(),
                 content = {
                     content()
                 }


### PR DESCRIPTION
## 📌 작업 내용
- FlintBasicBottomSheet 내부에 적용된 기본 패딩을 제거했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 하단 시트 컴포넌트의 불필요한 여백을 제거하여 콘텐츠가 전체 너비를 차지하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->