### PR TITLE
[Feat] collection create thumbnail

### DIFF
--- a/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
+++ b/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
@@ -1,0 +1,121 @@
+package com.flint.presentation.collectioncreate.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.flint.R
+import com.flint.core.common.extension.noRippleClickable
+import com.flint.core.designsystem.component.image.NetworkImage
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun CollectionCreateThumbnail(
+    imageUrl: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (imageUrl.isNullOrBlank()) {
+        CollectionCreateEmptyThumbnail(
+            onClick = onClick,
+            modifier = modifier
+        )
+    } else {
+        CollectionCreateFillThumbnail(
+            imageUrl = imageUrl,
+            onClick = onClick,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun CollectionCreateEmptyThumbnail(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .noRippleClickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.Center),
+            painter = painterResource(R.drawable.img_collection_bg1),
+            contentDescription = null,
+            tint = Color.Unspecified,
+        )
+
+        Icon(
+            modifier =
+                Modifier
+                    .align(Alignment.Center),
+            painter = painterResource(R.drawable.ic_background_photo),
+            contentDescription = null,
+            tint = Color.Unspecified,
+        )
+    }
+}
+
+@Composable
+private fun CollectionCreateFillThumbnail(
+    imageUrl: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .aspectRatio(1.5f / 1f)
+                .noRippleClickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        NetworkImage(
+            imageUrl = imageUrl,
+            modifier = Modifier
+                .fillMaxWidth(),
+        )
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(FlintTheme.colors.imgBlur),
+        )
+
+        Icon(
+            modifier =
+                Modifier
+                    .align(Alignment.Center),
+            painter = painterResource(R.drawable.ic_background_photo),
+            contentDescription = null,
+            tint = Color.Unspecified,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun CollectionCreateEmptyThumbnailPreview() {
+    FlintTheme {
+        CollectionCreateThumbnail(
+            imageUrl = "https://buly.kr/DEaVFRZ",
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
+++ b/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
@@ -2,7 +2,6 @@ package com.flint.presentation.collectioncreate.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,18 +21,18 @@ import com.flint.core.designsystem.theme.FlintTheme
 fun CollectionCreateThumbnail(
     imageUrl: String?,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     if (imageUrl.isNullOrBlank()) {
         CollectionCreateEmptyThumbnail(
             onClick = onClick,
-            modifier = modifier
+            modifier = modifier,
         )
     } else {
         CollectionCreateFillThumbnail(
             imageUrl = imageUrl,
             onClick = onClick,
-            modifier = modifier
+            modifier = modifier,
         )
     }
 }
@@ -87,8 +86,9 @@ private fun CollectionCreateFillThumbnail(
     ) {
         NetworkImage(
             imageUrl = imageUrl,
-            modifier = Modifier
-                .fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth(),
         )
 
         Box(
@@ -115,7 +115,7 @@ fun CollectionCreateEmptyThumbnailPreview() {
     FlintTheme {
         CollectionCreateThumbnail(
             imageUrl = "https://buly.kr/DEaVFRZ",
-            onClick = {}
+            onClick = {},
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
+++ b/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
@@ -53,7 +53,7 @@ private fun CollectionCreateEmptyThumbnail(
                 .fillMaxWidth()
                 .noRippleClickable(onClick = onClick),
         contentAlignment = Alignment.Center,
-    ) { 
+    ) {
         Image(
             modifier =
                 Modifier
@@ -64,9 +64,6 @@ private fun CollectionCreateEmptyThumbnail(
         )
 
         Icon(
-            modifier =
-                Modifier
-                    .align(Alignment.Center),
             painter = painterResource(R.drawable.ic_background_photo),
             contentDescription = null,
             tint = Color.Unspecified,
@@ -90,9 +87,7 @@ private fun CollectionCreateFillThumbnail(
     ) {
         NetworkImage(
             imageUrl = imageUrl,
-            modifier =
-                Modifier
-                    .fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
         )
 
         Box(
@@ -103,9 +98,6 @@ private fun CollectionCreateFillThumbnail(
         )
 
         Icon(
-            modifier =
-                Modifier
-                    .align(Alignment.Center),
             painter = painterResource(R.drawable.ic_background_photo),
             contentDescription = null,
             tint = Color.Unspecified,

--- a/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
+++ b/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
@@ -107,7 +107,7 @@ private fun CollectionCreateFillThumbnail(
 
 @Preview
 @Composable
-fun CollectionCreateEmptyThumbnailPreview() {
+fun CollectionCreateThumbnailPreview() {
     FlintTheme {
         Column {
             CollectionCreateThumbnail(

--- a/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
+++ b/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
@@ -2,9 +2,12 @@ package com.flint.presentation.collectioncreate.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.flint.R
 import com.flint.core.common.extension.noRippleClickable
 import com.flint.core.designsystem.component.image.NetworkImage
@@ -113,9 +117,18 @@ private fun CollectionCreateFillThumbnail(
 @Composable
 fun CollectionCreateEmptyThumbnailPreview() {
     FlintTheme {
-        CollectionCreateThumbnail(
-            imageUrl = "https://buly.kr/DEaVFRZ",
-            onClick = {},
-        )
+        Column {
+            CollectionCreateThumbnail(
+                imageUrl = "https://buly.kr/DEaVFRZ",
+                onClick = {},
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            CollectionCreateThumbnail(
+                imageUrl = null,
+                onClick = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
+++ b/app/src/main/java/com/flint/presentation/collectioncreate/component/CollectionCreateThumbnail.kt
@@ -1,5 +1,6 @@
 package com.flint.presentation.collectioncreate.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -52,15 +53,14 @@ private fun CollectionCreateEmptyThumbnail(
                 .fillMaxWidth()
                 .noRippleClickable(onClick = onClick),
         contentAlignment = Alignment.Center,
-    ) {
-        Icon(
+    ) { 
+        Image(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .align(Alignment.Center),
             painter = painterResource(R.drawable.img_collection_bg1),
             contentDescription = null,
-            tint = Color.Unspecified,
         )
 
         Icon(


### PR DESCRIPTION
## 📮 관련 이슈
- closed #71

## 📌 작업 내용
- collection create thumbnail

## 📸 스크린샷
| 스크린샷 |
<img width="714" height="800" alt="image" src="https://github.com/user-attachments/assets/452284ab-31b2-4ace-a842-33d5ac6f35d1" />

## 😅 미구현
- [ ] 

## 🫛 To. 리뷰어
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 컬렉션 생성용 클릭 가능한 썸네일 UI가 추가되었습니다. 이미지가 없으면 배경 이미지와 중앙 아이콘의 빈 상태를, 이미지가 있으면 고정 종횡비의 썸네일에 네트워크 이미지와 흐림 오버레이 및 아이콘 오버레이를 표시합니다. 클릭으로 동작을 트리거하며 프리뷰에서 빈/채움 상태를 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->