### PR TITLE
[Feat] SavedFilmListItem 제작

### DIFF
--- a/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
+++ b/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
@@ -33,15 +33,16 @@ import com.flint.R
 import com.flint.core.designsystem.component.image.NetworkImage
 import com.flint.core.designsystem.component.listView.OttHorizontalList
 import com.flint.core.designsystem.theme.FlintTheme
-import com.flint.domain.model.ContentModel
 import com.flint.domain.type.OttType
 
 @Composable
 fun SavedFilmListItem(
-    contentModel: ContentModel,
+    filmImage: String,
+    ottList: List<OttType>,
     title: String,
     director: String,
     createdYear: String,
+    onMoreFilmClick: () -> Unit,
     isBookmarked: Boolean,
     bookmarkCount: Int,
     onBookmarkClick: () -> Unit,
@@ -52,10 +53,12 @@ fun SavedFilmListItem(
             modifier
                 .fillMaxWidth()
                 .height(150.dp)
-                .background(color = FlintTheme.colors.background),
+                .background(color = FlintTheme.colors.background)
+                .padding(16.dp, 12.dp),
     ) {
         SavedFilmListItemImage(
-            contentModel = contentModel,
+            filmImage = filmImage,
+            ottList = ottList,
             modifier = Modifier.fillMaxHeight(),
         )
 
@@ -65,6 +68,7 @@ fun SavedFilmListItem(
             title = title,
             director = director,
             createdYear = createdYear,
+            onMoreFilmClick = onMoreFilmClick,
             modifier =
                 Modifier
                     .fillMaxHeight()
@@ -83,25 +87,24 @@ fun SavedFilmListItem(
 
 @Composable
 private fun SavedFilmListItemImage(
-    contentModel: ContentModel,
+    filmImage: String,
+    ottList: List<OttType>,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.width(100.dp),
+    Box(
+        modifier =
+            modifier
+                .width(100.dp)
+                .fillMaxSize(),
     ) {
-        Box(
+        NetworkImage(
+            imageUrl = filmImage,
             modifier = Modifier.fillMaxSize(),
-        ) {
-            NetworkImage(
-                imageUrl = contentModel.posterImage,
-                modifier = Modifier.fillMaxSize(),
-            )
-
-            OttHorizontalList(
-                ottList = contentModel.ottSimpleList,
-                modifier = Modifier.padding(top = 10.dp, start = 8.dp),
-            )
-        }
+        )
+        OttHorizontalList(
+            ottList = ottList,
+            modifier = Modifier.padding(top = 10.dp, start = 8.dp),
+        )
     }
 }
 
@@ -110,6 +113,7 @@ private fun SavedFilmListItemInfo(
     title: String,
     director: String,
     createdYear: String,
+    onMoreFilmClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -146,6 +150,7 @@ private fun SavedFilmListItemInfo(
         }
 
         Row(
+            modifier = Modifier.clickable(onClick = onMoreFilmClick),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -198,29 +203,17 @@ private fun SavedFilmListItemBookmark(
 @Composable
 private fun SavedFilmListItemBookmarkPreview() {
     FlintTheme {
-        val contentModel =
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목",
-                year = 2000,
-                posterImage = "",
-                ottSimpleList =
-                    listOf(
-                        OttType.Netflix,
-                        OttType.Disney,
-                        OttType.Tving,
-                        OttType.Coupang,
-                        OttType.Wave,
-                        OttType.Watcha,
-                    ),
-            )
         var isBookmarked by remember { mutableStateOf(false) }
 
+        val ottSimpleList = OttType.entries
+
         SavedFilmListItem(
-            contentModel = contentModel,
+            filmImage = "",
+            ottList = ottSimpleList,
             title = "해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔",
             director = "메롱",
             createdYear = "2005",
+            onMoreFilmClick = {},
             isBookmarked = isBookmarked,
             bookmarkCount = 128,
             onBookmarkClick = { isBookmarked = !isBookmarked },

--- a/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
+++ b/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
@@ -17,6 +17,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -86,10 +90,7 @@ private fun SavedFilmListItemImage(
         modifier = modifier.width(100.dp),
     ) {
         Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(180.dp),
+            modifier = Modifier.fillMaxSize(),
         ) {
             NetworkImage(
                 imageUrl = contentModel.posterImage,
@@ -197,7 +198,7 @@ private fun SavedFilmListItemBookmark(
 
 @Preview
 @Composable
-private fun CollectionCreateFilmSectionPreview() {
+private fun SavedFilmListItemBookmarkPreview() {
     FlintTheme {
         val contentModel =
             ContentModel(
@@ -215,15 +216,16 @@ private fun CollectionCreateFilmSectionPreview() {
                         OttType.Watcha,
                     ),
             )
+        var isBookmarked by remember { mutableStateOf(false) }
 
         SavedFilmListItem(
             contentModel = contentModel,
             title = "해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔",
             director = "메롱",
             createdYear = "2005",
-            isBookmarked = true,
+            isBookmarked = isBookmarked,
             bookmarkCount = 128,
-            onBookmarkClick = {},
+            onBookmarkClick = { isBookmarked = !isBookmarked },
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
+++ b/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
@@ -99,9 +99,7 @@ private fun SavedFilmListItemImage(
 
             OttHorizontalList(
                 ottList = contentModel.ottSimpleList,
-                modifier =
-                    Modifier
-                        .padding(top = 10.dp, start = 8.dp),
+                modifier = Modifier.padding(top = 10.dp, start = 8.dp),
             )
         }
     }
@@ -178,7 +176,7 @@ private fun SavedFilmListItemBookmark(
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(if (isBookmarked) R.drawable.ic_bookmark_fill else R.drawable.ic_bookmark_empty),
-            contentDescription = null,
+            contentDescription = "북마크",
             tint = Color.Unspecified,
             modifier =
                 Modifier

--- a/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
+++ b/app/src/main/java/com/flint/presentation/savedfilm/SavedFilmListItem.kt
@@ -1,0 +1,229 @@
+package com.flint.presentation.savedfilm
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.component.image.NetworkImage
+import com.flint.core.designsystem.component.listView.OttHorizontalList
+import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.domain.model.ContentModel
+import com.flint.domain.type.OttType
+
+@Composable
+fun SavedFilmListItem(
+    contentModel: ContentModel,
+    title: String,
+    director: String,
+    createdYear: String,
+    isBookmarked: Boolean,
+    bookmarkCount: Int,
+    onBookmarkClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(150.dp)
+                .background(color = FlintTheme.colors.background),
+    ) {
+        SavedFilmListItemImage(
+            contentModel = contentModel,
+            modifier = Modifier.fillMaxHeight(),
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        SavedFilmListItemInfo(
+            title = title,
+            director = director,
+            createdYear = createdYear,
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .weight(1f),
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        SavedFilmListItemBookmark(
+            isBookmarked = isBookmarked,
+            bookmarkCount = bookmarkCount,
+            onBookmarkClick = onBookmarkClick,
+        )
+    }
+}
+
+@Composable
+private fun SavedFilmListItemImage(
+    contentModel: ContentModel,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.width(100.dp),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(180.dp),
+        ) {
+            NetworkImage(
+                imageUrl = contentModel.posterImage,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            OttHorizontalList(
+                ottList = contentModel.ottSimpleList,
+                modifier =
+                    Modifier
+                        .padding(top = 10.dp, start = 8.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SavedFilmListItemInfo(
+    title: String,
+    director: String,
+    createdYear: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = title,
+                modifier = Modifier.fillMaxWidth(),
+                color = FlintTheme.colors.white,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 2,
+                style = FlintTheme.typography.body1M16,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = director,
+                modifier = Modifier.fillMaxWidth(),
+                color = FlintTheme.colors.gray300,
+                style = FlintTheme.typography.caption1M12,
+            )
+
+            Text(
+                text = createdYear,
+                modifier = Modifier.fillMaxWidth(),
+                color = FlintTheme.colors.gray300,
+                style = FlintTheme.typography.caption1M12,
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "작품 보러가기",
+                color = FlintTheme.colors.white,
+                style = FlintTheme.typography.body2R14,
+            )
+
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_more),
+                modifier = Modifier.size(16.dp),
+                contentDescription = null,
+                tint = Color.Unspecified,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SavedFilmListItemBookmark(
+    isBookmarked: Boolean,
+    bookmarkCount: Int,
+    onBookmarkClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.size(48.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(if (isBookmarked) R.drawable.ic_bookmark_fill else R.drawable.ic_bookmark_empty),
+            contentDescription = null,
+            tint = Color.Unspecified,
+            modifier =
+                Modifier
+                    .size(24.dp)
+                    .clickable(onClick = onBookmarkClick),
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        Text(
+            text = "$bookmarkCount",
+            color = FlintTheme.colors.gray50,
+            style = FlintTheme.typography.caption1M12,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CollectionCreateFilmSectionPreview() {
+    FlintTheme {
+        val contentModel =
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목",
+                year = 2000,
+                posterImage = "",
+                ottSimpleList =
+                    listOf(
+                        OttType.Netflix,
+                        OttType.Disney,
+                        OttType.Tving,
+                        OttType.Coupang,
+                        OttType.Wave,
+                        OttType.Watcha,
+                    ),
+            )
+
+        SavedFilmListItem(
+            contentModel = contentModel,
+            title = "해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔 해리포터 불의 잔",
+            director = "메롱",
+            createdYear = "2005",
+            isBookmarked = true,
+            bookmarkCount = 128,
+            onBookmarkClick = {},
+        )
+    }
+}


### PR DESCRIPTION
## 📮 관련 이슈
- closed #78

## 📌 작업 내용
- SavedFilmListItem 제작

## 📸 스크린샷
| 스크린샷 |
<img width="842" height="392" alt="image" src="https://github.com/user-attachments/assets/bc9d726e-6b19-406e-9dda-58711af3857b" />

## 😅 미구현
- [ ] 

## 🫛 To. 리뷰어
- 함수명이 공통컴포넌트에 있는 SavedContentItem과 비슷한거 같아서 고민이에용..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 저장된 영화 항목 카드 추가: 포스터(네트워크 이미지)와 OTT 오버레이, 제목·감독·개봉연도 표시.
  * "작품 보러가기" 액션과 북마크 토글 및 북마크 개수 표시 지원.
  * 이미지·정보·북마크 영역으로 분리된 개선된 레이아웃과 디자인 테마 적용.
  * 미리보기로 북마크 동작 및 UI 확인 가능, 리스트/상세에서 일관된 표시 제공.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->