### PR TITLE
[Feat] SaveToast 구현

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/snackbar/SaveToast.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/snackbar/SaveToast.kt
@@ -1,0 +1,91 @@
+package com.flint.core.designsystem.component.snackbar
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun SaveToast(
+    // TODO: 이름 추천 해주세요
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .padding(horizontal = 11.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(FlintTheme.colors.gray900)
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_gradient_bookmark),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+        )
+
+        Spacer(Modifier.width(20.dp))
+
+        Column {
+            Text(
+                text = "취향이 하나 더 쌓였어요",
+                color = FlintTheme.colors.white,
+                style = FlintTheme.typography.body1Sb16,
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Row(
+                modifier = Modifier.clickable(onClick = onClick),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "저장한 컬렉션 보러가기",
+                    color = FlintTheme.colors.gray200,
+                    style = FlintTheme.typography.body2R14,
+                )
+
+                Icon(
+                    painter = painterResource(R.drawable.ic_more),
+                    contentDescription = null,
+                    tint = FlintTheme.colors.gray200,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SaveToastPreview() {
+    FlintTheme {
+        SaveToast(
+            onClick = {},
+        )
+    }
+}


### PR DESCRIPTION
## 📮 관련 이슈
- closed #87 

## 📌 작업 내용
- SaveToast 구현했어요.
  - 사실상 Content에요.
- Toast를 컴포즈에서 띄우는 방법은 https://github.com/imflint/Flint-Android/issues/86 에서 해결해요.

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <img width="609" height="206" alt="스크린샷 2026-01-14 오전 6 48 57" src="https://github.com/user-attachments/assets/54ba9cfc-fcff-43ef-9dfe-44872dc529d0" /> |

## 🫛 To. 리뷰어
- 여러분들과 함께해서 행복해요 ☺️


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 저장 완료 알림 토스트 컴포넌트 추가
  * 사용자가 저장한 컬렉션 목록으로 빠르게 이동할 수 있는 링크 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->