### PR TITLE
[Feat] UnderImageProgressBar 구현

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/progressbar/UnderImageProgressBar.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/progressbar/UnderImageProgressBar.kt
@@ -1,0 +1,55 @@
+package com.flint.core.designsystem.component.progressbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun UnderImageProgressBar(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .height(5.dp)
+                .background(FlintTheme.colors.gray700),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth(progress)
+                    .fillMaxHeight()
+                    .clip(CircleShape)
+                    .background(FlintTheme.colors.secondary500),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UnderImageProgressBarPreview(
+    @PreviewParameter(UnderImageProgressBarPreviewParameterProvider::class) progress: Float,
+) {
+    FlintTheme {
+        UnderImageProgressBar(
+            progress = progress,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+private class UnderImageProgressBarPreviewParameterProvider : PreviewParameterProvider<Float> {
+    override val values: Sequence<Float> = sequenceOf(0f, 0.25f, 0.5f, 0.75f, 1f)
+}


### PR DESCRIPTION
## 📮 관련 이슈
- closed #91 

## 📌 작업 내용
- `UnderImageProgressBar` 구현

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <img width="589" height="223" alt="스크린샷 2026-01-14 오후 2 50 42" src="https://github.com/user-attachments/assets/b131dc78-226e-4f69-aaf1-2748d1ccf011" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 이미지 아래에 진행 상황을 시각적으로 표시하는 진행률 표시줄 컴포넌트가 추가되었습니다. 회색 배경 위에 테마 색상의 채우기 막대가 표시되며, 0부터 1.0까지의 다양한 진행 상태를 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->