### PR TITLE
[Feat] Home UI

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/listItem/CollectionItem.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/listItem/CollectionItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.rememberAsyncImagePainter
@@ -74,7 +75,7 @@ fun CollectionItem(
             modifier =
                 Modifier
                     .align(Alignment.BottomStart)
-                    .padding(start = 14.dp, bottom = 10.dp),
+                    .padding(start = 14.dp, bottom = 10.dp, end = 14.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Image(
@@ -95,12 +96,16 @@ fun CollectionItem(
                     text = collectionModel.collectionTitle,
                     style = FlintTheme.typography.body2M14,
                     color = FlintTheme.colors.gray50,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
                 )
 
                 Text(
                     text = collectionModel.author.nickname,
                     style = FlintTheme.typography.caption1R12,
                     color = FlintTheme.colors.gray200,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
                 )
             }
         }

--- a/app/src/main/java/com/flint/core/designsystem/component/listItem/SavedContentItem.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/listItem/SavedContentItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.flint.core.common.extension.noRippleClickable
 import com.flint.core.designsystem.component.image.NetworkImage
 import com.flint.core.designsystem.component.listView.OttHorizontalList
 import com.flint.core.designsystem.theme.FlintTheme
@@ -23,12 +24,15 @@ import com.flint.domain.type.OttType
 @Composable
 fun SavedContentItem(
     contentModel: ContentModel,
+    onItemClick: (contentId: Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier =
-            modifier
-                .width(120.dp),
+        modifier = modifier
+            .width(120.dp)
+            .noRippleClickable {
+                onItemClick(contentModel.contentId)
+            },
     ) {
         Box(
             modifier =
@@ -91,6 +95,7 @@ private fun PreviewSavedContentItem() {
 
         SavedContentItem(
             contentModel = contentModel,
+            onItemClick = {}
         )
     }
 }

--- a/app/src/main/java/com/flint/core/designsystem/component/listItem/SavedContentItem.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/listItem/SavedContentItem.kt
@@ -28,11 +28,12 @@ fun SavedContentItem(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .width(120.dp)
-            .noRippleClickable {
-                onItemClick(contentModel.contentId)
-            },
+        modifier =
+            modifier
+                .width(120.dp)
+                .noRippleClickable {
+                    onItemClick(contentModel.contentId)
+                },
     ) {
         Box(
             modifier =
@@ -95,7 +96,7 @@ private fun PreviewSavedContentItem() {
 
         SavedContentItem(
             contentModel = contentModel,
-            onItemClick = {}
+            onItemClick = {},
         )
     }
 }

--- a/app/src/main/java/com/flint/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/flint/core/designsystem/theme/Color.kt
@@ -58,6 +58,7 @@ data class Colors(
     val gradient900: Brush,
     val gradient700: Brush,
     val gradient400: Brush,
+    val gradient400Secondary: Brush,
     val imgBlur: Brush,
     val imgBlurHigh: Brush,
     val pink: Color,
@@ -118,6 +119,10 @@ val FlintColors =
         gradient400 =
             Brush.linearGradient(
                 colors = listOf(Color(0xFF1ABFF2), Color(0xFF86EBFF)),
+            ),
+        gradient400Secondary =
+            Brush.verticalGradient(
+                colors = listOf(Color(0xFF8991FF), Color(0xFF6B75FF)),
             ),
         imgBlur =
             Brush.verticalGradient(
@@ -356,6 +361,11 @@ private fun FlintColorsPreview() {
             Box(
                 Modifier
                     .background(brush = FlintColors.gradient400)
+                    .size(100.dp),
+            )
+            Box(
+                Modifier
+                    .background(brush = FlintColors.gradient400Secondary)
                     .size(100.dp),
             )
             Box(

--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -22,7 +22,7 @@ interface Route {
     data object CollectionList : Route
 
     @Serializable
-    data object CollectionDetail : Route
+    data class CollectionDetail(val collectionId: String) : Route
 
     @Serializable
     data object CollectionCreate : Route

--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -22,7 +22,9 @@ interface Route {
     data object CollectionList : Route
 
     @Serializable
-    data class CollectionDetail(val collectionId: String) : Route
+    data class CollectionDetail(
+        val collectionId: String,
+    ) : Route
 
     @Serializable
     data object CollectionCreate : Route

--- a/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 @Composable
 fun CollectionDetailRoute(
     paddingValues: PaddingValues,
+    collectionId: String,
     navigateToCollectionList: () -> Unit,
 ) {
     CollectionDetailScreen()

--- a/app/src/main/java/com/flint/presentation/collectiondetail/navigation/CollectionDetailNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/navigation/CollectionDetailNavigation.kt
@@ -5,11 +5,15 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.flint.core.navigation.Route
 import com.flint.presentation.collectiondetail.CollectionDetailRoute
 
-fun NavController.navigateToCollectionDetail(navOptions: NavOptions? = null) {
-    navigate(Route.CollectionDetail, navOptions)
+fun NavController.navigateToCollectionDetail(
+    collectionId: String,
+    navOptions: NavOptions? = null,
+) {
+    navigate(Route.CollectionDetail(collectionId = collectionId), navOptions)
 }
 
 fun NavGraphBuilder.collectionDetailNavGraph(
@@ -17,8 +21,10 @@ fun NavGraphBuilder.collectionDetailNavGraph(
     navigateToCollectionList: () -> Unit,
 ) {
     composable<Route.CollectionDetail> {
+        val collectionDetail = it.toRoute<Route.CollectionDetail>()
         CollectionDetailRoute(
             paddingValues = paddingValues,
+            collectionId = collectionDetail.collectionId,
             navigateToCollectionList = navigateToCollectionList,
         )
     }

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 @Composable
 fun CollectionListRoute(
     paddingValues: PaddingValues,
-    navigateToCollectionDetail: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {
     CollectionListScreen()
 }

--- a/app/src/main/java/com/flint/presentation/collectionlist/navigation/CollectionListNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/navigation/CollectionListNavigation.kt
@@ -14,7 +14,7 @@ fun NavController.navigateToCollectionList(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.collectionListNavGraph(
     paddingValues: PaddingValues,
-    navigateToCollectionDetail: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {
     composable<Route.CollectionList> {
         CollectionListRoute(

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -14,7 +14,7 @@ import com.flint.core.designsystem.theme.FlintTheme
 @Composable
 fun ExploreRoute(
     paddingValues: PaddingValues,
-    navigateToCollectionDetail: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
     navigateToCollectionCreate: () -> Unit,
 ) {
     ExploreScreen(

--- a/app/src/main/java/com/flint/presentation/explore/navigation/ExploreNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/explore/navigation/ExploreNavigation.kt
@@ -14,7 +14,7 @@ fun NavController.navigateToExplore(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.exploreNavGraph(
     paddingValues: PaddingValues,
-    navigateToCollectionDetail: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
     navigateToCollectionCreate: () -> Unit,
 ) {
     composable<MainTabRoute.Explore> {

--- a/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.flint.presentation.home
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -7,8 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,9 +19,12 @@ import com.flint.core.designsystem.component.topappbar.FlintLogoTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.AuthorModel
 import com.flint.domain.model.CollectionModel
+import com.flint.domain.model.ContentModel
+import com.flint.domain.type.OttType
 import com.flint.domain.type.UserRoleType
 import com.flint.presentation.home.component.HomeBanner
 import com.flint.presentation.home.component.HomeRecommendCollection
+import com.flint.presentation.home.component.HomeSavedContents
 
 @Composable
 fun HomeRoute(
@@ -33,24 +37,33 @@ fun HomeRoute(
         onRecommendCollectionItemClick = { collectionId ->
             navigateToCollectionDetail(collectionId)
         },
+        onSavedContentItemClick = { contentId ->
+            //TODO show OttListBottomSheet
+        },
         modifier = Modifier.padding(paddingValues),
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HomeScreen(
     userName: String = "",
     collectionModelList: List<CollectionModel> = emptyList(),
+    contentModelList: List<ContentModel> = emptyList(),
     onRecommendCollectionItemClick: (collectionId: String) -> Unit = {},
+    onSavedContentItemClick: (contentId: Long) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
             .background(FlintTheme.colors.background)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .statusBarsPadding(),
         contentAlignment = Alignment.Center,
     ) {
+
         LazyColumn(
+            overscrollEffect = null,
             modifier = Modifier.fillMaxSize()
         ) {
             stickyHeader {
@@ -75,6 +88,18 @@ private fun HomeScreen(
                     }
                 )
             }
+
+            item {
+                Spacer(Modifier.height(48.dp))
+
+                HomeSavedContents(
+                    contentModelList = contentModelList,
+                    onItemClick = { contentId ->
+                        onSavedContentItemClick(contentId)
+                    }
+                )
+            }
+
         }
     }
 }
@@ -112,10 +137,56 @@ private fun PreviewHomeScreen() {
             ),
         )
 
+        val contentModelList = listOf(
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목",
+                year = 2000,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Netflix,
+                    OttType.Disney,
+                    OttType.Tving,
+                    OttType.Coupang
+                )
+            ),
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목2",
+                year = 2020,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Wave,
+                    OttType.Watcha,
+                    OttType.Tving,
+                )
+            ),
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목3",
+                year = 2003,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Disney,
+                    OttType.Tving,
+                )
+            ),
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목4",
+                year = 1919,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Watcha
+                )
+            )
+        )
+
 
         HomeScreen(
             userName = "종우",
             collectionModelList = collectionModelList,
+            contentModelList = contentModelList
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
@@ -3,13 +3,20 @@ package com.flint.presentation.home
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.component.topappbar.FlintLogoTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.presentation.home.component.HomeBanner
 
 @Composable
 fun HomeRoute(
@@ -18,22 +25,50 @@ fun HomeRoute(
     navigateToCollectionCreate: () -> Unit,
 ) {
     HomeScreen(
+        userName = "종우",
         modifier = Modifier.padding(paddingValues),
     )
 }
 
 @Composable
-private fun HomeScreen(modifier: Modifier = Modifier) {
+private fun HomeScreen(
+    userName: String,
+    modifier: Modifier = Modifier
+) {
     Box(
-        modifier =
-            modifier
-                .background(FlintTheme.colors.background)
-                .fillMaxSize(),
+        modifier = modifier
+            .background(FlintTheme.colors.background)
+            .fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = "HomeScreen",
-            color = FlintTheme.colors.white,
-        )
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            stickyHeader {
+                FlintLogoTopAppbar()
+            }
+
+            item {
+                Spacer(Modifier.height(5.dp))
+
+                HomeBanner(
+                    userName = userName
+                )
+            }
+
+            item {
+                Spacer(Modifier.height(48.dp))
+
+
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeScreen() {
+    FlintTheme {
+        HomeScreen(userName = "종우",)
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
@@ -16,23 +16,32 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.flint.core.designsystem.component.topappbar.FlintLogoTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.domain.model.AuthorModel
+import com.flint.domain.model.CollectionModel
+import com.flint.domain.type.UserRoleType
 import com.flint.presentation.home.component.HomeBanner
+import com.flint.presentation.home.component.HomeRecommendCollection
 
 @Composable
 fun HomeRoute(
     paddingValues: PaddingValues,
     navigateToCollectionList: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
     navigateToCollectionCreate: () -> Unit,
 ) {
     HomeScreen(
-        userName = "종우",
+        onRecommendCollectionItemClick = { collectionId ->
+            navigateToCollectionDetail(collectionId)
+        },
         modifier = Modifier.padding(paddingValues),
     )
 }
 
 @Composable
 private fun HomeScreen(
-    userName: String,
+    userName: String = "",
+    collectionModelList: List<CollectionModel> = emptyList(),
+    onRecommendCollectionItemClick: (collectionId: String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -59,7 +68,12 @@ private fun HomeScreen(
             item {
                 Spacer(Modifier.height(48.dp))
 
-
+                HomeRecommendCollection(
+                    collectionModelList = collectionModelList,
+                    onItemClick = { collectionId ->
+                        onRecommendCollectionItemClick(collectionId)
+                    }
+                )
             }
         }
     }
@@ -69,6 +83,39 @@ private fun HomeScreen(
 @Composable
 private fun PreviewHomeScreen() {
     FlintTheme {
-        HomeScreen(userName = "종우",)
+        val collectionModelList = listOf(
+            CollectionModel(
+                collectionId = "",
+                collectionTitle = "컬렉션 제목",
+                collectionImageUrl = "",
+                createdAt = "",
+                isBookmarked = false,
+                author = AuthorModel(
+                    userId = 0,
+                    nickname = "사용자 이름",
+                    profileUrl = "",
+                    userRole = UserRoleType.FLINER
+                )
+            ),
+            CollectionModel(
+                collectionId = "",
+                collectionTitle = "컬렉션 제목2",
+                collectionImageUrl = "",
+                createdAt = "",
+                isBookmarked = false,
+                author = AuthorModel(
+                    userId = 0,
+                    nickname = "사용자 이름2",
+                    profileUrl = "",
+                    userRole = UserRoleType.FLINER
+                )
+            ),
+        )
+
+
+        HomeScreen(
+            userName = "종우",
+            collectionModelList = collectionModelList,
+        )
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
@@ -116,6 +116,7 @@ private fun HomeScreen(
                     HomeRecentCollectionEmpty(navigateToExplore = navigateToExplore)
                 } else {
                     HomeRecentCollection(
+                        userName = userName,
                         collectionModelList = recentCollectionModelList,
                         onItemClick = { collectionId ->
                             onRecentCollectionItemClick(collectionId)

--- a/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
@@ -23,6 +23,9 @@ import com.flint.domain.model.ContentModel
 import com.flint.domain.type.OttType
 import com.flint.domain.type.UserRoleType
 import com.flint.presentation.home.component.HomeBanner
+import com.flint.presentation.home.component.HomeFab
+import com.flint.presentation.home.component.HomeRecentCollection
+import com.flint.presentation.home.component.HomeRecentCollectionEmpty
 import com.flint.presentation.home.component.HomeRecommendCollection
 import com.flint.presentation.home.component.HomeSavedContents
 
@@ -38,7 +41,7 @@ fun HomeRoute(
             navigateToCollectionDetail(collectionId)
         },
         onSavedContentItemClick = { contentId ->
-            //TODO show OttListBottomSheet
+            // TODO show OttListBottomSheet
         },
         modifier = Modifier.padding(paddingValues),
     )
@@ -48,23 +51,29 @@ fun HomeRoute(
 @Composable
 private fun HomeScreen(
     userName: String = "",
-    collectionModelList: List<CollectionModel> = emptyList(),
-    contentModelList: List<ContentModel> = emptyList(),
+    recommendCollectionModelList: List<CollectionModel> = emptyList(),
+    savedContentModelList: List<ContentModel> = emptyList(),
+    recentCollectionModelList: List<CollectionModel> = emptyList(),
     onRecommendCollectionItemClick: (collectionId: String) -> Unit = {},
     onSavedContentItemClick: (contentId: Long) -> Unit = {},
-    modifier: Modifier = Modifier
+    onRecentCollectionItemClick: (collectionId: String) -> Unit = {},
+    onRecentCollectionAllClick: () -> Unit = {},
+    navigateToExplore: () -> Unit = {},
+    navigateToCollectionCreate: () -> Unit = {},
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .background(FlintTheme.colors.background)
-            .fillMaxSize()
-            .statusBarsPadding(),
+        modifier =
+            modifier
+                .background(FlintTheme.colors.background)
+                .fillMaxSize()
+                .statusBarsPadding(),
         contentAlignment = Alignment.Center,
     ) {
-
         LazyColumn(
             overscrollEffect = null,
-            modifier = Modifier.fillMaxSize()
+            contentPadding = PaddingValues(bottom = 80.dp),
+            modifier = Modifier.fillMaxSize(),
         ) {
             stickyHeader {
                 FlintLogoTopAppbar()
@@ -74,7 +83,7 @@ private fun HomeScreen(
                 Spacer(Modifier.height(5.dp))
 
                 HomeBanner(
-                    userName = userName
+                    userName = userName,
                 )
             }
 
@@ -82,10 +91,10 @@ private fun HomeScreen(
                 Spacer(Modifier.height(48.dp))
 
                 HomeRecommendCollection(
-                    collectionModelList = collectionModelList,
+                    collectionModelList = recommendCollectionModelList,
                     onItemClick = { collectionId ->
                         onRecommendCollectionItemClick(collectionId)
-                    }
+                    },
                 )
             }
 
@@ -93,14 +102,40 @@ private fun HomeScreen(
                 Spacer(Modifier.height(48.dp))
 
                 HomeSavedContents(
-                    contentModelList = contentModelList,
+                    contentModelList = savedContentModelList,
                     onItemClick = { contentId ->
                         onSavedContentItemClick(contentId)
-                    }
+                    },
                 )
             }
 
+            item {
+                Spacer(Modifier.height(48.dp))
+
+                if (recentCollectionModelList.isEmpty()) {
+                    HomeRecentCollectionEmpty(navigateToExplore = navigateToExplore)
+                } else {
+                    HomeRecentCollection(
+                        collectionModelList = recentCollectionModelList,
+                        onItemClick = { collectionId ->
+                            onRecentCollectionItemClick(collectionId)
+                        },
+                        onAllClick = {
+                            onRecentCollectionAllClick()
+                        },
+                    )
+                }
+            }
         }
+
+        /** FAB **/
+        HomeFab(
+            onClick = navigateToCollectionCreate,
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 16.dp, bottom = 8.dp),
+        )
     }
 }
 
@@ -108,85 +143,93 @@ private fun HomeScreen(
 @Composable
 private fun PreviewHomeScreen() {
     FlintTheme {
-        val collectionModelList = listOf(
-            CollectionModel(
-                collectionId = "",
-                collectionTitle = "컬렉션 제목",
-                collectionImageUrl = "",
-                createdAt = "",
-                isBookmarked = false,
-                author = AuthorModel(
-                    userId = 0,
-                    nickname = "사용자 이름",
-                    profileUrl = "",
-                    userRole = UserRoleType.FLINER
-                )
-            ),
-            CollectionModel(
-                collectionId = "",
-                collectionTitle = "컬렉션 제목2",
-                collectionImageUrl = "",
-                createdAt = "",
-                isBookmarked = false,
-                author = AuthorModel(
-                    userId = 0,
-                    nickname = "사용자 이름2",
-                    profileUrl = "",
-                    userRole = UserRoleType.FLINER
-                )
-            ),
-        )
-
-        val contentModelList = listOf(
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목",
-                year = 2000,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Netflix,
-                    OttType.Disney,
-                    OttType.Tving,
-                    OttType.Coupang
-                )
-            ),
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목2",
-                year = 2020,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Wave,
-                    OttType.Watcha,
-                    OttType.Tving,
-                )
-            ),
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목3",
-                year = 2003,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Disney,
-                    OttType.Tving,
-                )
-            ),
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목4",
-                year = 1919,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Watcha
-                )
+        val collectionModelList =
+            listOf(
+                CollectionModel(
+                    collectionId = "",
+                    collectionTitle = "컬렉션 제목",
+                    collectionImageUrl = "",
+                    createdAt = "",
+                    isBookmarked = false,
+                    author =
+                        AuthorModel(
+                            userId = 0,
+                            nickname = "사용자 이름",
+                            profileUrl = "",
+                            userRole = UserRoleType.FLINER,
+                        ),
+                ),
+                CollectionModel(
+                    collectionId = "",
+                    collectionTitle = "컬렉션 제목2",
+                    collectionImageUrl = "",
+                    createdAt = "",
+                    isBookmarked = false,
+                    author =
+                        AuthorModel(
+                            userId = 0,
+                            nickname = "사용자 이름2",
+                            profileUrl = "",
+                            userRole = UserRoleType.FLINER,
+                        ),
+                ),
             )
-        )
 
+        val contentModelList =
+            listOf(
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목",
+                    year = 2000,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Netflix,
+                            OttType.Disney,
+                            OttType.Tving,
+                            OttType.Coupang,
+                        ),
+                ),
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목2",
+                    year = 2020,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Wave,
+                            OttType.Watcha,
+                            OttType.Tving,
+                        ),
+                ),
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목3",
+                    year = 2003,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Disney,
+                            OttType.Tving,
+                        ),
+                ),
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목4",
+                    year = 1919,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Watcha,
+                        ),
+                ),
+            )
 
         HomeScreen(
             userName = "종우",
-            collectionModelList = collectionModelList,
-            contentModelList = contentModelList
+            recommendCollectionModelList = collectionModelList,
+            savedContentModelList = contentModelList,
+            recentCollectionModelList = collectionModelList, // or 'emptyList()'
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/component/HomeBanner.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeBanner.kt
@@ -1,0 +1,52 @@
+package com.flint.presentation.home.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun HomeBanner(
+    userName: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(270.dp)
+            .paint(
+                painter = painterResource(id = R.drawable.img_collection_bg2),
+                contentScale = ContentScale.FillBounds
+            )
+    ) {
+        Text(
+            text = "반가워요, $userName 님\n오늘은 어떤 작품이 끌리세요?",
+            style = FlintTheme.typography.head1Sb22,
+            color = FlintTheme.colors.white,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 16.dp, bottom = 30.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeBanner() {
+    FlintTheme {
+        HomeBanner(
+            userName = "종우"
+        )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/home/component/HomeBanner.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeBanner.kt
@@ -19,24 +19,26 @@ import com.flint.core.designsystem.theme.FlintTheme
 @Composable
 fun HomeBanner(
     userName: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(270.dp)
-            .paint(
-                painter = painterResource(id = R.drawable.img_collection_bg2),
-                contentScale = ContentScale.FillBounds
-            )
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(270.dp)
+                .paint(
+                    painter = painterResource(id = R.drawable.img_collection_bg2),
+                    contentScale = ContentScale.FillBounds,
+                ),
     ) {
         Text(
             text = "반가워요, $userName 님\n오늘은 어떤 작품이 끌리세요?",
             style = FlintTheme.typography.head1Sb22,
             color = FlintTheme.colors.white,
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 16.dp, bottom = 30.dp)
+            modifier =
+                Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 16.dp, bottom = 30.dp),
         )
     }
 }
@@ -46,7 +48,7 @@ fun HomeBanner(
 private fun PreviewHomeBanner() {
     FlintTheme {
         HomeBanner(
-            userName = "종우"
+            userName = "종우",
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/component/HomeFab.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeFab.kt
@@ -1,0 +1,52 @@
+package com.flint.presentation.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun HomeFab(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .clip(CircleShape)
+                .background(FlintTheme.colors.gradient400Secondary)
+                .size(48.dp)
+                .clickable { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_plus),
+            tint = Color.Unspecified,
+            contentDescription = null,
+            modifier = Modifier.size(32.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeFab() {
+    FlintTheme {
+        HomeFab(
+            onClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/home/component/HomeRecentCollection.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeRecentCollection.kt
@@ -3,17 +3,26 @@ package com.flint.presentation.home.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.common.extension.noRippleClickable
 import com.flint.core.designsystem.component.listItem.CollectionItem
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.AuthorModel
@@ -21,9 +30,10 @@ import com.flint.domain.model.CollectionModel
 import com.flint.domain.type.UserRoleType
 
 @Composable
-fun HomeRecommendCollection(
+fun HomeRecentCollection(
     collectionModelList: List<CollectionModel>,
     onItemClick: (id: String) -> Unit,
+    onAllClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -31,21 +41,45 @@ fun HomeRecommendCollection(
             modifier
                 .fillMaxWidth(),
     ) {
-        Text(
-            text = "Fliner의 추천 컬렉션을 만나보세요",
-            style = FlintTheme.typography.head3Sb18,
-            color = FlintTheme.colors.white,
-            modifier = Modifier.padding(start = 16.dp),
-        )
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(end = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(
+                    text = "눈여겨보고 있는 컬렉션",
+                    style = FlintTheme.typography.head3Sb18,
+                    color = FlintTheme.colors.white,
+                    modifier = Modifier.padding(start = 16.dp),
+                )
 
-        Spacer(Modifier.height(4.dp))
+                Spacer(Modifier.height(4.dp))
 
-        Text(
-            text = "Fliner는 콘텐츠에 진심인, 플린트의 큐레이터들이에요",
-            style = FlintTheme.typography.body2R14,
-            color = FlintTheme.colors.white,
-            modifier = Modifier.padding(start = 16.dp),
-        )
+                Text(
+                    text = "키카님이 최근 살펴본 컬렉션이에요",
+                    style = FlintTheme.typography.body2R14,
+                    color = FlintTheme.colors.white,
+                    modifier = Modifier.padding(start = 16.dp),
+                )
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_more),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier =
+                    Modifier
+                        .size(24.dp)
+                        .noRippleClickable {
+                            onAllClick()
+                        },
+            )
+        }
 
         Spacer(Modifier.height(24.dp))
 
@@ -66,9 +100,9 @@ fun HomeRecommendCollection(
     }
 }
 
-@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Preview
 @Composable
-private fun PreviewHomeRecommentCollection() {
+private fun PreviewHomeRecentCollection() {
     FlintTheme {
         val collectionModelList =
             listOf(
@@ -102,9 +136,10 @@ private fun PreviewHomeRecommentCollection() {
                 ),
             )
 
-        HomeRecommendCollection(
+        HomeRecentCollection(
             collectionModelList = collectionModelList,
-            onItemClick = {},
+            onItemClick = { },
+            onAllClick = { },
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/component/HomeRecentCollection.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeRecentCollection.kt
@@ -31,6 +31,7 @@ import com.flint.domain.type.UserRoleType
 
 @Composable
 fun HomeRecentCollection(
+    userName: String,
     collectionModelList: List<CollectionModel>,
     onItemClick: (id: String) -> Unit,
     onAllClick: () -> Unit,
@@ -59,7 +60,7 @@ fun HomeRecentCollection(
                 Spacer(Modifier.height(4.dp))
 
                 Text(
-                    text = "키카님이 최근 살펴본 컬렉션이에요",
+                    text = "${userName}님이 최근 살펴본 컬렉션이에요",
                     style = FlintTheme.typography.body2R14,
                     color = FlintTheme.colors.white,
                     modifier = Modifier.padding(start = 16.dp),
@@ -137,6 +138,7 @@ private fun PreviewHomeRecentCollection() {
             )
 
         HomeRecentCollection(
+            userName = "종우",
             collectionModelList = collectionModelList,
             onItemClick = { },
             onAllClick = { },

--- a/app/src/main/java/com/flint/presentation/home/component/HomeRecentCollectionEmpty.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeRecentCollectionEmpty.kt
@@ -1,0 +1,66 @@
+package com.flint.presentation.home.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.component.button.FlintBasicButton
+import com.flint.core.designsystem.component.button.FlintButtonState
+import com.flint.core.designsystem.theme.FlintTheme
+
+@Composable
+fun HomeRecentCollectionEmpty(
+    navigateToExplore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+    ) {
+        Text(
+            text = "아직 읽어본 컬렉션이 없어요",
+            style = FlintTheme.typography.head3Sb18,
+            color = FlintTheme.colors.white,
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        Text(
+            text = "천천히 둘러보며 끌리는 취향을 발견해보세요",
+            style = FlintTheme.typography.body2R14,
+            color = FlintTheme.colors.gray100,
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        FlintBasicButton(
+            text = "취향 발견하러 가기",
+            state = FlintButtonState.Able,
+            onClick = navigateToExplore,
+            contentPadding = PaddingValues(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeRecentCollectionEmpty() {
+    FlintTheme {
+        HomeRecentCollectionEmpty(
+            navigateToExplore = {},
+        )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/home/component/HomeRecommendCollection.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeRecommendCollection.kt
@@ -1,0 +1,107 @@
+package com.flint.presentation.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.component.listItem.CollectionItem
+import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.domain.model.AuthorModel
+import com.flint.domain.model.CollectionModel
+import com.flint.domain.type.UserRoleType
+
+@Composable
+fun HomeRecommendCollection(
+    collectionModelList: List<CollectionModel>,
+    onItemClick: (id: String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = "Fliner의 추천 컬렉션을 만나보세요",
+            style = FlintTheme.typography.head3Sb18,
+            color = FlintTheme.colors.white,
+            modifier = Modifier.padding(start = 16.dp)
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        Text(
+            text = "Fliner는 콘텐츠에 진심인, 플린트의 큐레이터들이에요",
+            style = FlintTheme.typography.body2R14,
+            color = FlintTheme.colors.white,
+            modifier = Modifier.padding(start = 16.dp)
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            itemsIndexed(collectionModelList) { _, item ->
+                CollectionItem(
+                    collectionModel = item,
+                    onItemClick = { id ->
+                        onItemClick(id)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Composable
+private fun PreviewHomeRecommentCollection() {
+    FlintTheme {
+        val collectionModelList = listOf(
+            CollectionModel(
+                collectionId = "",
+                collectionTitle = "컬렉션 제목",
+                collectionImageUrl = "",
+                createdAt = "",
+                isBookmarked = false,
+                author = AuthorModel(
+                    userId = 0,
+                    nickname = "사용자 이름",
+                    profileUrl = "",
+                    userRole = UserRoleType.FLINER
+                )
+            ),
+            CollectionModel(
+                collectionId = "",
+                collectionTitle = "컬렉션 제목2",
+                collectionImageUrl = "",
+                createdAt = "",
+                isBookmarked = false,
+                author = AuthorModel(
+                    userId = 0,
+                    nickname = "사용자 이름2",
+                    profileUrl = "",
+                    userRole = UserRoleType.FLINER
+                )
+            ),
+        )
+
+        HomeRecommendCollection(
+            collectionModelList = collectionModelList,
+            onItemClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/home/component/HomeRecommendCollection.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeRecommendCollection.kt
@@ -68,7 +68,7 @@ fun HomeRecommendCollection(
 
 @Preview(showBackground = true, backgroundColor = 0xFF121212)
 @Composable
-private fun PreviewHomeRecommentCollection() {
+private fun PreviewHomeRecommendCollection() {
     FlintTheme {
         val collectionModelList =
             listOf(

--- a/app/src/main/java/com/flint/presentation/home/component/HomeSavedContents.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeSavedContents.kt
@@ -1,0 +1,123 @@
+package com.flint.presentation.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.component.listItem.CollectionItem
+import com.flint.core.designsystem.component.listItem.SavedContentItem
+import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.domain.model.ContentModel
+import com.flint.domain.type.OttType
+
+@Composable
+fun HomeSavedContents(
+    contentModelList: List<ContentModel>,
+    onItemClick: (contentId: Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = "최근 저장한 콘텐츠 ",
+            style = FlintTheme.typography.head3Sb18,
+            color = FlintTheme.colors.white,
+            modifier = Modifier.padding(start = 16.dp)
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        Text(
+            text = "현재 구독 중인 OTT에서 볼 수 있는 작품들이에요",
+            style = FlintTheme.typography.body2R14,
+            color = FlintTheme.colors.white,
+            modifier = Modifier.padding(start = 16.dp)
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            itemsIndexed(contentModelList) { _, item ->
+                SavedContentItem(
+                    contentModel = item,
+                    onItemClick = { contentId ->
+                        onItemClick(contentId)
+                    }
+                )
+            }
+        }
+
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeSavedContents() {
+    FlintTheme {
+        val contentModelList = listOf(
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목",
+                year = 2000,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Netflix,
+                    OttType.Disney,
+                    OttType.Tving,
+                    OttType.Coupang
+                )
+            ),
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목2",
+                year = 2020,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Wave,
+                    OttType.Watcha,
+                    OttType.Tving,
+                )
+            ),
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목3",
+                year = 2003,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Disney,
+                    OttType.Tving,
+                )
+            ),
+            ContentModel(
+                contentId = 0,
+                title = "드라마 제목4",
+                year = 1919,
+                posterImage = "",
+                ottSimpleList = listOf(
+                    OttType.Watcha
+                )
+            )
+        )
+
+        HomeSavedContents(
+            contentModelList = contentModelList,
+            onItemClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/home/component/HomeSavedContents.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeSavedContents.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.flint.core.designsystem.component.listItem.CollectionItem
 import com.flint.core.designsystem.component.listItem.SavedContentItem
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.ContentModel
@@ -24,17 +23,18 @@ import com.flint.domain.type.OttType
 fun HomeSavedContents(
     contentModelList: List<ContentModel>,
     onItemClick: (contentId: Long) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxWidth()
+        modifier =
+            modifier
+                .fillMaxWidth(),
     ) {
         Text(
             text = "최근 저장한 콘텐츠 ",
             style = FlintTheme.typography.head3Sb18,
             color = FlintTheme.colors.white,
-            modifier = Modifier.padding(start = 16.dp)
+            modifier = Modifier.padding(start = 16.dp),
         )
 
         Spacer(Modifier.height(4.dp))
@@ -43,7 +43,7 @@ fun HomeSavedContents(
             text = "현재 구독 중인 OTT에서 볼 수 있는 작품들이에요",
             style = FlintTheme.typography.body2R14,
             color = FlintTheme.colors.white,
-            modifier = Modifier.padding(start = 16.dp)
+            modifier = Modifier.padding(start = 16.dp),
         )
 
         Spacer(Modifier.height(24.dp))
@@ -51,18 +51,17 @@ fun HomeSavedContents(
         LazyRow(
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             itemsIndexed(contentModelList) { _, item ->
                 SavedContentItem(
                     contentModel = item,
                     onItemClick = { contentId ->
                         onItemClick(contentId)
-                    }
+                    },
                 )
             }
         }
-
     }
 }
 
@@ -70,54 +69,59 @@ fun HomeSavedContents(
 @Composable
 private fun PreviewHomeSavedContents() {
     FlintTheme {
-        val contentModelList = listOf(
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목",
-                year = 2000,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Netflix,
-                    OttType.Disney,
-                    OttType.Tving,
-                    OttType.Coupang
-                )
-            ),
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목2",
-                year = 2020,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Wave,
-                    OttType.Watcha,
-                    OttType.Tving,
-                )
-            ),
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목3",
-                year = 2003,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Disney,
-                    OttType.Tving,
-                )
-            ),
-            ContentModel(
-                contentId = 0,
-                title = "드라마 제목4",
-                year = 1919,
-                posterImage = "",
-                ottSimpleList = listOf(
-                    OttType.Watcha
-                )
+        val contentModelList =
+            listOf(
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목",
+                    year = 2000,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Netflix,
+                            OttType.Disney,
+                            OttType.Tving,
+                            OttType.Coupang,
+                        ),
+                ),
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목2",
+                    year = 2020,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Wave,
+                            OttType.Watcha,
+                            OttType.Tving,
+                        ),
+                ),
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목3",
+                    year = 2003,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Disney,
+                            OttType.Tving,
+                        ),
+                ),
+                ContentModel(
+                    contentId = 0,
+                    title = "드라마 제목4",
+                    year = 1919,
+                    posterImage = "",
+                    ottSimpleList =
+                        listOf(
+                            OttType.Watcha,
+                        ),
+                ),
             )
-        )
 
         HomeSavedContents(
             contentModelList = contentModelList,
-            onItemClick = {}
+            onItemClick = {},
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/home/component/HomeSavedContents.kt
+++ b/app/src/main/java/com/flint/presentation/home/component/HomeSavedContents.kt
@@ -31,7 +31,7 @@ fun HomeSavedContents(
                 .fillMaxWidth(),
     ) {
         Text(
-            text = "최근 저장한 콘텐츠 ",
+            text = "최근 저장한 콘텐츠",
             style = FlintTheme.typography.head3Sb18,
             color = FlintTheme.colors.white,
             modifier = Modifier.padding(start = 16.dp),

--- a/app/src/main/java/com/flint/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/home/navigation/HomeNavigation.kt
@@ -15,12 +15,14 @@ fun NavController.navigateToHome(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.homeNavGraph(
     paddingValues: PaddingValues,
     navigateToCollectionList: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
     navigateToCollectionCreate: () -> Unit,
 ) {
     composable<MainTabRoute.Home> {
         HomeRoute(
             paddingValues = paddingValues,
             navigateToCollectionList = navigateToCollectionList,
+            navigateToCollectionDetail = navigateToCollectionDetail,
             navigateToCollectionCreate = navigateToCollectionCreate,
         )
     }

--- a/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
@@ -56,6 +56,7 @@ fun MainNavHost(
             homeNavGraph(
                 paddingValues = paddingValues,
                 navigateToCollectionList = navigator::navigateToCollectionList,
+                navigateToCollectionDetail = navigator::navigateToCollectionDetail,
                 navigateToCollectionCreate = navigator::navigateToCollectionCreate,
             )
 

--- a/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
@@ -116,8 +116,8 @@ class MainNavigator(
         navController.navigateToCollectionList()
     }
 
-    fun navigateToCollectionDetail() {
-        navController.navigateToCollectionDetail()
+    fun navigateToCollectionDetail(collectionId: String) {
+        navController.navigateToCollectionDetail(collectionId = collectionId)
     }
 
     fun navigateToCollectionCreate() {

--- a/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
@@ -16,7 +16,7 @@ fun ProfileRoute(
     paddingValues: PaddingValues,
     navigateToCollectionList: () -> Unit,
     navigateToSavedFilmList: () -> Unit,
-    navigateToCollectionDetail: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {
     ProfileScreen(
         modifier = Modifier.padding(paddingValues),

--- a/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
@@ -16,7 +16,7 @@ fun NavGraphBuilder.profileNavGraph(
     paddingValues: PaddingValues,
     navigateToCollectionList: () -> Unit,
     navigateToSavedFilmList: () -> Unit,
-    navigateToCollectionDetail: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {
     composable<MainTabRoute.Profile> {
         ProfileRoute(


### PR DESCRIPTION
## 📮 관련 이슈
- closed #99 

## 📌 작업 내용
- 홈 UI 작업
- 홈의 각 컴포넌트 분리

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <img width="380" height="832" alt="스크린샷 2026-01-15 오전 3 06 38" src="https://github.com/user-attachments/assets/b85c66f4-d6de-49d8-905f-fccbc627a53d" /> |

<img width="390" height="853" alt="스크린샷 2026-01-15 오전 3 07 36" src="https://github.com/user-attachments/assets/680088cb-e199-4a85-8229-53f1ddb95f65" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 홈 화면에 프로필 배너, 저장된 콘텐츠, 추천 컬렉션, 최근 컬렉션 섹션 추가
  * 컬렉션 생성 버튼(FAB) 추가
  * 컬렉션 및 저장된 콘텐츠 항목에서 컬렉션 상세로 이동(항목 클릭) 가능

* **스타일**
  * 새로운 그라디언트 색상 추가
  * 컬렉션 제목/작성자 텍스트에 한 줄 말줄임표(줄바꿈 및 트렁케이션) 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->