### PR TITLE
[Feat] 커스텀 토스트/스낵바 띄우는 방법

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/snackbar/SaveToast.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/snackbar/SaveToast.kt
@@ -27,8 +27,7 @@ import com.flint.core.designsystem.theme.FlintTheme
 
 @Composable
 fun SaveToast(
-    // TODO: 이름 추천 해주세요
-    onClick: () -> Unit,
+    navigateToSavedCollection: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -60,7 +59,7 @@ fun SaveToast(
             Spacer(Modifier.height(4.dp))
 
             Row(
-                modifier = Modifier.clickable(onClick = onClick),
+                modifier = Modifier.clickable(onClick = navigateToSavedCollection),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
@@ -85,7 +84,7 @@ fun SaveToast(
 private fun SaveToastPreview() {
     FlintTheme {
         SaveToast(
-            onClick = {},
+            navigateToSavedCollection = {},
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
+++ b/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
@@ -1,0 +1,64 @@
+package com.flint.presentation.toast
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.component.snackbar.SaveToast
+import com.flint.core.designsystem.theme.FlintTheme
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.seconds
+
+@Composable
+fun ShowSaveToast(
+    collectionId: Long,
+    navigateToSavedCollection: (collectionId: Long) -> Unit,
+    yOffset: Dp,
+    hideToast: () -> Unit,
+) {
+    LaunchedEffect(Unit) {
+        delay(2.seconds)
+        hideToast()
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        SaveToast(
+            navigateToSavedCollection = { navigateToSavedCollection(collectionId) },
+            modifier = Modifier.padding(bottom = yOffset),
+        )
+
+        Spacer(Modifier.height(yOffset))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ShowSaveToastPreview() {
+    FlintTheme {
+        var show: Boolean by remember { mutableStateOf(true) }
+
+        if (show) {
+            ShowSaveToast(
+                collectionId = 1L,
+                navigateToSavedCollection = {},
+                yOffset = 80.dp,
+                hideToast = { show = false },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
+++ b/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
@@ -1,9 +1,7 @@
 package com.flint.presentation.toast
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,14 +21,13 @@ import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun ShowSaveToast(
-    collectionId: Long,
-    navigateToSavedCollection: (collectionId: Long) -> Unit,
+    navigateToSavedCollection: () -> Unit,
     yOffset: Dp,
-    hideToast: () -> Unit,
+    hide: () -> Unit,
 ) {
     LaunchedEffect(Unit) {
         delay(2.seconds)
-        hideToast()
+        hide()
     }
 
     Box(
@@ -38,11 +35,10 @@ fun ShowSaveToast(
         contentAlignment = Alignment.BottomCenter,
     ) {
         SaveToast(
-            navigateToSavedCollection = { navigateToSavedCollection(collectionId) },
+            navigateToSavedCollection = navigateToSavedCollection,
             modifier = Modifier.padding(bottom = yOffset),
         )
     }
-}
 }
 
 @Preview(showBackground = true)
@@ -53,10 +49,9 @@ private fun ShowSaveToastPreview() {
 
         if (show) {
             ShowSaveToast(
-                collectionId = 1L,
                 navigateToSavedCollection = {},
                 yOffset = 80.dp,
-                hideToast = { show = false },
+                hide = { show = false },
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
+++ b/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
@@ -41,15 +41,8 @@ fun ShowSaveToast(
             navigateToSavedCollection = { navigateToSavedCollection(collectionId) },
             modifier = Modifier.padding(bottom = yOffset),
         )
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.BottomCenter,
-    ) {
-        SaveToast(
-            navigateToSavedCollection = { navigateToSavedCollection(collectionId) },
-            modifier = Modifier.padding(bottom = yOffset),
-        )
     }
+}
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
+++ b/app/src/main/java/com/flint/presentation/toast/ShowSaveToast.kt
@@ -41,8 +41,14 @@ fun ShowSaveToast(
             navigateToSavedCollection = { navigateToSavedCollection(collectionId) },
             modifier = Modifier.padding(bottom = yOffset),
         )
-
-        Spacer(Modifier.height(yOffset))
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        SaveToast(
+            navigateToSavedCollection = { navigateToSavedCollection(collectionId) },
+            modifier = Modifier.padding(bottom = yOffset),
+        )
     }
 }
 

--- a/app/src/main/java/com/flint/presentation/toast/ShowToast.kt
+++ b/app/src/main/java/com/flint/presentation/toast/ShowToast.kt
@@ -27,11 +27,11 @@ fun ShowToast(
     text: String,
     imageVector: ImageVector?,
     yOffset: Dp,
-    hideToast: () -> Unit,
+    hide: () -> Unit,
 ) {
     LaunchedEffect(Unit) {
         delay(2.seconds)
-        hideToast()
+        hide()
     }
 
     Box(
@@ -57,13 +57,13 @@ private fun ShowToastPreview() {
                 text = "저장되었습니다",
                 imageVector = ImageVector.vectorResource(R.drawable.ic_check),
                 yOffset = 80.dp,
-                hideToast = { show = false },
+                hide = { show = false },
             )
         }
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 private fun ShowToastWithoutIconPreview() {
     FlintTheme {
@@ -74,7 +74,7 @@ private fun ShowToastWithoutIconPreview() {
                 text = "알림 메시지입니다",
                 imageVector = null,
                 yOffset = 80.dp,
-                hideToast = { show = false },
+                hide = { show = false },
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/toast/ShowToast.kt
+++ b/app/src/main/java/com/flint/presentation/toast/ShowToast.kt
@@ -1,0 +1,81 @@
+package com.flint.presentation.toast
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.flint.R
+import com.flint.core.designsystem.component.toast.FlintToast
+import com.flint.core.designsystem.theme.FlintTheme
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.seconds
+
+@Composable
+fun ShowToast(
+    text: String,
+    imageVector: ImageVector?,
+    yOffset: Dp,
+    hideToast: () -> Unit,
+) {
+    LaunchedEffect(Unit) {
+        delay(2.seconds)
+        hideToast()
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        FlintToast(
+            text = text,
+            imageVector = imageVector,
+            modifier = Modifier.padding(bottom = yOffset),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ShowToastPreview() {
+    FlintTheme {
+        var show: Boolean by remember { mutableStateOf(true) }
+
+        if (show) {
+            ShowToast(
+                text = "저장되었습니다",
+                imageVector = ImageVector.vectorResource(R.drawable.ic_check),
+                yOffset = 80.dp,
+                hideToast = { show = false },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ShowToastWithoutIconPreview() {
+    FlintTheme {
+        var show: Boolean by remember { mutableStateOf(true) }
+
+        if (show) {
+            ShowToast(
+                text = "알림 메시지입니다",
+                imageVector = null,
+                yOffset = 80.dp,
+                hideToast = { show = false },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 📮 관련 이슈
- closed #86 

## 📸 스크린샷

| 스크린샷 | 스크린샷 | 스크린샷 |
|:--:|:--:|:--:|
| <video width="360" src="https://github.com/user-attachments/assets/a9f32ff1-3ff8-43d4-85e7-211f1b95ab4d" /> | <video width="360" src="https://github.com/user-attachments/assets/3208ccc7-fe3f-4357-874f-537c9a9098fb" /> | <video width="360" src="https://github.com/user-attachments/assets/2ba12d0c-7d56-418b-88cc-40fa3683ea96" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 컬렉션 저장 성공 시 화면 하단에 표시되는 저장 토스트 추가 — 토스트에서 저장된 컬렉션으로 바로 이동 가능
  * 일반 토스트 표시 컴포넌트 추가 — 아이콘 유무와 위치(yOffset) 조정 가능
  * 각 토스트는 표시 후 2초 뒤 자동으로 사라져 간결한 사용자 피드백 제공

* **수정**
  * 저장 토스트의 동작 연결 방식이 업데이트되어 이동 흐름이 더 일관성 있게 동작하도록 개선됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->