### PR TITLE
[Feat] 컬렉션 리스트 화면 UI 구현

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintSearchTextField.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/textfield/FlintSearchTextField.kt
@@ -24,10 +24,11 @@ fun FlintSearchTextField(
     value: String,
     onValueChanged: (String) -> Unit,
     placeholder: String,
+    modifier: Modifier = Modifier,
     onSearchAction: () -> Unit = {},
 ) {
     FlintBasicTextField(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         placeholder = placeholder,
         value = value,
         onValueChange = onValueChanged,

--- a/app/src/main/java/com/flint/domain/model/AuthorModel.kt
+++ b/app/src/main/java/com/flint/domain/model/AuthorModel.kt
@@ -7,4 +7,14 @@ data class AuthorModel(
     val nickname: String,
     val profileUrl: String,
     val userRole: UserRoleType,
-)
+) {
+    companion object {
+        val Fake =
+            AuthorModel(
+                userId = 1L,
+                nickname = "작성자 닉네임",
+                profileUrl = "",
+                userRole = UserRoleType.FLINER,
+            )
+    }
+}

--- a/app/src/main/java/com/flint/domain/model/CollectionDetailModel.kt
+++ b/app/src/main/java/com/flint/domain/model/CollectionDetailModel.kt
@@ -10,4 +10,19 @@ data class CollectionDetailModel(
     val isBookmarked: Boolean,
     val bookmarkCount: Int,
     val author: AuthorModel,
-)
+) {
+    companion object {
+        val Fake =
+            CollectionDetailModel(
+                collectionId = "id_0",
+                collectionTitle = "컬렉션 제목 1",
+                collectionContent = "컬렉션에 대한 설명이 들어갑니다. 최대 2줄까지 표시됩니다.",
+                collectionImageUrl1 = "",
+                collectionImageUrl2 = "",
+                createdAt = "2024-01-01",
+                isBookmarked = true,
+                bookmarkCount = 10,
+                author = AuthorModel.Fake,
+            )
+    }
+}

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
@@ -25,11 +25,11 @@ import androidx.compose.ui.unit.dp
 import com.flint.core.designsystem.component.textfield.FlintSearchTextField
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.domain.model.AuthorModel
 import com.flint.domain.model.CollectionDetailModel
 import com.flint.presentation.collectionlist.component.CollectionFileItem
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun CollectionListRoute(
@@ -119,12 +119,56 @@ private fun CollectionListScreenPreview() {
         CollectionListScreen(
             onBackClick = {},
             title = "전체 컬렉션",
-            collections =
-                List(6) { index ->
-                    CollectionDetailModel.Fake.copy(
-                        collectionId = index.toString(),
-                    )
-                }.toImmutableList(),
+            collections = persistentListOf(
+                CollectionDetailModel.Fake.copy(
+                    collectionId = "1",
+                    collectionTitle = "2024 인생 영화 모음",
+                    collectionContent = "올해 본 영화 중 최고만 모았습니다",
+                    isBookmarked = true,
+                    bookmarkCount = 128,
+                    author = AuthorModel.Fake.copy(nickname = "닉네임은여덟글자"),
+                ),
+                CollectionDetailModel.Fake.copy(
+                    collectionId = "2",
+                    collectionTitle = "혼자 보기 아까운 숨은 명작",
+                    collectionContent = "알려지지 않은 갓작들",
+                    isBookmarked = false,
+                    bookmarkCount = 56,
+                    author = AuthorModel.Fake.copy(nickname = "시네필"),
+                ),
+                CollectionDetailModel.Fake.copy(
+                    collectionId = "3",
+                    collectionTitle = "비 오는 날 보기 좋은 영화",
+                    collectionContent = "감성 충전용 영화 컬렉션입니다. 우울할 때 보면 좋아요.",
+                    isBookmarked = true,
+                    bookmarkCount = 234,
+                    author = AuthorModel.Fake.copy(nickname = "무비러버"),
+                ),
+                CollectionDetailModel.Fake.copy(
+                    collectionId = "4",
+                    collectionTitle = "넷플릭스 정주행 리스트",
+                    collectionContent = "주말에 몰아보기 좋은 시리즈",
+                    isBookmarked = false,
+                    bookmarkCount = 89,
+                    author = AuthorModel.Fake,
+                ),
+                CollectionDetailModel.Fake.copy(
+                    collectionId = "5",
+                    collectionTitle = "SF 덕후 추천작",
+                    collectionContent = "우주와 미래를 다룬 SF 명작 모음",
+                    isBookmarked = true,
+                    bookmarkCount = 412,
+                    author = AuthorModel.Fake.copy(nickname = "SF매니아"),
+                ),
+                CollectionDetailModel.Fake.copy(
+                    collectionId = "6",
+                    collectionTitle = "첫 데이트용 무난한 영화",
+                    collectionContent = "어색한 분위기를 풀어줄 영화들",
+                    isBookmarked = false,
+                    bookmarkCount = 67,
+                    author = AuthorModel.Fake.copy(nickname = "연애고수"),
+                ),
+            ),
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
@@ -2,6 +2,7 @@ package com.flint.presentation.collectionlist
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -22,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.flint.core.designsystem.component.textfield.FlintSearchTextField
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.AuthorModel
@@ -68,18 +68,6 @@ private fun CollectionListScreen(
 
         Spacer(Modifier.height(12.dp))
 
-        FlintSearchTextField(
-            placeholder = "컬렉션을 검색해보세요",
-            value = text,
-            onValueChanged = { text = it },
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-        )
-
-        Spacer(Modifier.height(12.dp))
-
         Text(
             text = "총 ${collections.size}개",
             color = FlintTheme.colors.gray100,
@@ -92,21 +80,26 @@ private fun CollectionListScreen(
         Spacer(Modifier.height(24.dp))
 
         LazyVerticalGrid(
+            contentPadding = PaddingValues(10.dp),
             columns = GridCells.Fixed(2),
             horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier =
                 Modifier
-                    .padding(start = 20.dp)
-                    .fillMaxSize(),
+                    .padding(horizontal = 10.dp),
         ) {
             items(
                 items = collections,
                 key = { it.collectionId },
             ) { collection ->
-                CollectionFileItem(
-                    collection = collection,
-                )
+                Box(modifier = Modifier.fillMaxSize(1f).align(Alignment.CenterHorizontally)) {
+                    CollectionFileItem(
+                        collection = collection,
+                        modifier =
+                            Modifier
+                                .align(Alignment.Center),
+                    )
+                }
             }
         }
     }
@@ -119,56 +112,57 @@ private fun CollectionListScreenPreview() {
         CollectionListScreen(
             onBackClick = {},
             title = "전체 컬렉션",
-            collections = persistentListOf(
-                CollectionDetailModel.Fake.copy(
-                    collectionId = "1",
-                    collectionTitle = "2024 인생 영화 모음",
-                    collectionContent = "올해 본 영화 중 최고만 모았습니다",
-                    isBookmarked = true,
-                    bookmarkCount = 128,
-                    author = AuthorModel.Fake.copy(nickname = "닉네임은여덟글자"),
+            collections =
+                persistentListOf(
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = "1",
+                        collectionTitle = "2024 인생 영화 모음",
+                        collectionContent = "올해 본 영화 중 최고만 모았습니다",
+                        isBookmarked = true,
+                        bookmarkCount = 128,
+                        author = AuthorModel.Fake.copy(nickname = "닉네임은여덟글자"),
+                    ),
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = "2",
+                        collectionTitle = "혼자 보기 아까운 숨은 명작",
+                        collectionContent = "알려지지 않은 갓작들",
+                        isBookmarked = false,
+                        bookmarkCount = 56,
+                        author = AuthorModel.Fake.copy(nickname = "시네필"),
+                    ),
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = "3",
+                        collectionTitle = "비 오는 날 보기 좋은 영화",
+                        collectionContent = "감성 충전용 영화 컬렉션입니다. 우울할 때 보면 좋아요.",
+                        isBookmarked = true,
+                        bookmarkCount = 234,
+                        author = AuthorModel.Fake.copy(nickname = "무비러버"),
+                    ),
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = "4",
+                        collectionTitle = "넷플릭스 정주행 리스트",
+                        collectionContent = "주말에 몰아보기 좋은 시리즈",
+                        isBookmarked = false,
+                        bookmarkCount = 89,
+                        author = AuthorModel.Fake,
+                    ),
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = "5",
+                        collectionTitle = "SF 덕후 추천작",
+                        collectionContent = "우주와 미래를 다룬 SF 명작 모음",
+                        isBookmarked = true,
+                        bookmarkCount = 412,
+                        author = AuthorModel.Fake.copy(nickname = "SF매니아"),
+                    ),
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = "6",
+                        collectionTitle = "첫 데이트용 무난한 영화",
+                        collectionContent = "어색한 분위기를 풀어줄 영화들",
+                        isBookmarked = false,
+                        bookmarkCount = 67,
+                        author = AuthorModel.Fake.copy(nickname = "연애고수"),
+                    ),
                 ),
-                CollectionDetailModel.Fake.copy(
-                    collectionId = "2",
-                    collectionTitle = "혼자 보기 아까운 숨은 명작",
-                    collectionContent = "알려지지 않은 갓작들",
-                    isBookmarked = false,
-                    bookmarkCount = 56,
-                    author = AuthorModel.Fake.copy(nickname = "시네필"),
-                ),
-                CollectionDetailModel.Fake.copy(
-                    collectionId = "3",
-                    collectionTitle = "비 오는 날 보기 좋은 영화",
-                    collectionContent = "감성 충전용 영화 컬렉션입니다. 우울할 때 보면 좋아요.",
-                    isBookmarked = true,
-                    bookmarkCount = 234,
-                    author = AuthorModel.Fake.copy(nickname = "무비러버"),
-                ),
-                CollectionDetailModel.Fake.copy(
-                    collectionId = "4",
-                    collectionTitle = "넷플릭스 정주행 리스트",
-                    collectionContent = "주말에 몰아보기 좋은 시리즈",
-                    isBookmarked = false,
-                    bookmarkCount = 89,
-                    author = AuthorModel.Fake,
-                ),
-                CollectionDetailModel.Fake.copy(
-                    collectionId = "5",
-                    collectionTitle = "SF 덕후 추천작",
-                    collectionContent = "우주와 미래를 다룬 SF 명작 모음",
-                    isBookmarked = true,
-                    bookmarkCount = 412,
-                    author = AuthorModel.Fake.copy(nickname = "SF매니아"),
-                ),
-                CollectionDetailModel.Fake.copy(
-                    collectionId = "6",
-                    collectionTitle = "첫 데이트용 무난한 영화",
-                    collectionContent = "어색한 분위기를 풀어줄 영화들",
-                    isBookmarked = false,
-                    bookmarkCount = 67,
-                    author = AuthorModel.Fake.copy(nickname = "연애고수"),
-                ),
-            ),
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
@@ -1,16 +1,130 @@
 package com.flint.presentation.collectionlist
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flint.core.designsystem.component.textfield.FlintSearchTextField
+import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
+import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.domain.model.CollectionDetailModel
+import com.flint.presentation.collectionlist.component.CollectionFileItem
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun CollectionListRoute(
     paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
     navigateToCollectionDetail: () -> Unit,
 ) {
-    CollectionListScreen()
+    CollectionListScreen(
+        onBackClick = navigateUp,
+        title = "전체 컬렉션",
+        modifier = Modifier.padding(paddingValues),
+        collections = persistentListOf(), // TODO: 변경 필요
+    )
 }
 
 @Composable
-fun CollectionListScreen() {
+private fun CollectionListScreen(
+    onBackClick: () -> Unit,
+    title: String,
+    collections: ImmutableList<CollectionDetailModel>,
+    modifier: Modifier = Modifier,
+) {
+    var text by remember { mutableStateOf("") }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(FlintTheme.colors.background),
+    ) {
+        FlintBackTopAppbar(
+            onClick = onBackClick,
+            title = title,
+            backgroundColor = FlintTheme.colors.background,
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        FlintSearchTextField(
+            placeholder = "컬렉션을 검색해보세요",
+            value = text,
+            onValueChanged = { text = it },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        Text(
+            text = "총 ${collections.size}개",
+            color = FlintTheme.colors.gray100,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier =
+                Modifier
+                    .padding(start = 20.dp)
+                    .fillMaxSize(),
+        ) {
+            items(
+                items = collections,
+                key = { it.collectionId },
+            ) { collection ->
+                CollectionFileItem(
+                    collection = collection,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun CollectionListScreenPreview() {
+    FlintTheme {
+        CollectionListScreen(
+            onBackClick = {},
+            title = "전체 컬렉션",
+            collections =
+                List(6) { index ->
+                    CollectionDetailModel.Fake.copy(
+                        collectionId = index.toString(),
+                    )
+                }.toImmutableList(),
+        )
+    }
 }

--- a/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -76,6 +77,7 @@ fun CollectionFileItem(
                 color = FlintTheme.colors.gray300,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.height(45.dp)
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -55,7 +54,9 @@ fun CollectionFileItem(
                 bookmarkCount = bookmarkCount,
                 poster1Url = collectionImageUrl1,
                 poster2Url = collectionImageUrl2,
-                modifier = Modifier.size(154.dp),
+                modifier =
+                    Modifier
+                        .size(154.dp),
             )
         }
 
@@ -77,7 +78,7 @@ fun CollectionFileItem(
                 color = FlintTheme.colors.gray300,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.height(45.dp)
+                modifier = Modifier.height(45.dp),
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/collectionlist/navigation/CollectionListNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/navigation/CollectionListNavigation.kt
@@ -14,11 +14,13 @@ fun NavController.navigateToCollectionList(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.collectionListNavGraph(
     paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
     navigateToCollectionDetail: () -> Unit,
 ) {
     composable<Route.CollectionList> {
         CollectionListRoute(
             paddingValues = paddingValues,
+            navigateUp = navigateUp,
             navigateToCollectionDetail = navigateToCollectionDetail,
         )
     }

--- a/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
@@ -61,6 +61,7 @@ fun MainNavHost(
 
             collectionListNavGraph(
                 paddingValues = paddingValues,
+                navigateUp = navigator::navigateUp,
                 navigateToCollectionDetail = navigator::navigateToCollectionDetail,
             )
 


### PR DESCRIPTION
## 📮 관련 이슈
- closed #이슈번호

## 📌 작업 내용
- 컬렉션 리스트 화면 UI 구현했어요.

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <video width="360" src="https://github.com/user-attachments/assets/56fac730-df0c-4502-9753-72e6d8cbe562" /> |



## 😅 미구현
- N/A

## 🫛 To. 리뷰어
- 리스트 뜨는 화면이 원래 여러 개 있는데, 기존 프로필 화면에서 진입했을 때의 검색바가 삭제돼서, title만 바꾸는 걸로 우선 구현하도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 컬렉션 목록 화면 추가: 뒤로가기 버튼 및 컬렉션 그리드 표시 기능 구현

* **리팩토링**
  * 검색 필드 모디파이어 커스터마이제이션 개선

* **스타일**
  * 컬렉션 항목 UI 높이 조정

* **테스트**
  * 모델 테스트 데이터 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->