### PR TITLE
[Style] FlintIconButton 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/button/FlintBasicButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -55,7 +54,8 @@ fun FlintBasicButton(
                     } else {
                         this
                     }
-                }.clip(shape)
+                }
+                .clip(shape)
                 .background(background)
                 .clickable(enabled = enabled, onClick = onClick)
                 .padding(contentPadding),
@@ -63,37 +63,21 @@ fun FlintBasicButton(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (leadingIconRes != null) {
-            Box(
-                modifier = Modifier.weight(1f),
-                contentAlignment = Alignment.CenterEnd,
-            ) {
-                Icon(
-                    painter = painterResource(leadingIconRes),
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = contentColor,
-                )
-            }
-
-            Spacer(Modifier.width(4.dp))
-
-            Box(
-                modifier = Modifier.weight(1f),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                Text(
-                    text = text,
-                    color = contentColor,
-                    style = if (enabled) FlintTheme.typography.body1Sb16 else FlintTheme.typography.body1M16,
-                )
-            }
-        } else {
-            Text(
-                text = text,
-                color = contentColor,
-                style = if (enabled) FlintTheme.typography.body1Sb16 else FlintTheme.typography.body1M16,
+            Icon(
+                painter = painterResource(leadingIconRes),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 4.dp)
+                    .size(24.dp),
+                tint = contentColor,
             )
         }
+
+        Text(
+            text = text,
+            color = contentColor,
+            style = if (enabled) FlintTheme.typography.body1Sb16 else FlintTheme.typography.body1M16,
+        )
     }
 }
 


### PR DESCRIPTION
## 📮 관련 이슈
- closed #112 

## 📌 작업 내용
- 버튼 내 아이콘과 텍스트의 배치 방식을 가중치(weight) 기반에서 고정 간격(padding) 기반으로 변경
- 불필요한 Box 컴포넌트 제거 및 코드 구조 단순화
- 클릭 가능한 영역에 대한 Modifier 체이닝 순서 및 포맷팅 수정

## 📸 스크린샷
| AS-IS | TO-BE |
|:--:|:--:|
| <img width="507" height="238" alt="스크린샷 2026-01-18 오전 1 55 15" src="https://github.com/user-attachments/assets/bdbd2684-d3c4-4aa7-9723-8981ec427e2f" /> | <img width="505" height="246" alt="스크린샷 2026-01-18 오전 1 54 54" src="https://github.com/user-attachments/assets/9de7f91c-75b4-4faf-9d09-fb677b1dde03" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized button component rendering with leading icons for improved layout efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->