### PR TITLE
[Feat] 그라데이션 방향 및 오프셋 설정

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/flint/core/designsystem/theme/Color.kt
@@ -10,8 +10,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.LinearGradientShader
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -109,18 +114,33 @@ val FlintColors =
         error700 = Color(0xFFB53746),
         overlay = Color(0xFF000000).copy(alpha = 0.6f),
         spoilerBlur = Color(0xFF121212).copy(alpha = 0.3f),
-        gradient900 =
-            Brush.linearGradient(
-                colors = listOf(Color(0xFF3C4256), Color(0xFF121212)),
-            ),
-        gradient700 =
-            Brush.linearGradient(
-                colors = listOf(Color(0xFF3C4256), Color(0xFF2B2F3A)),
-            ),
-        gradient400 =
-            Brush.linearGradient(
-                colors = listOf(Color(0xFF1ABFF2), Color(0xFF86EBFF)),
-            ),
+        gradient900 = object : ShaderBrush() {
+            override fun createShader(size: Size): Shader {
+                return LinearGradientShader(
+                    from = Offset(size.width * 0.12f, 0f),
+                    to = Offset(size.width * 0.50f, size.height * 0.59f),
+                    colors = listOf(Color(0xFF3C4256), Color(0xFF121212))
+                )
+            }
+        },
+        gradient700 = object : ShaderBrush() {
+            override fun createShader(size: Size): Shader {
+                return LinearGradientShader(
+                    from = Offset.Zero,
+                    to = Offset(size.width * 0.355f, size.height * 0.44f),
+                    colors = listOf(Color(0xFF3C4256), Color(0xFF2B2F3A))
+                )
+            }
+        },
+        gradient400 = object : ShaderBrush() {
+            override fun createShader(size: Size): Shader {
+                return LinearGradientShader(
+                    from = Offset.Zero,
+                    to = Offset(size.width * 0.25f, size.height),
+                    colors = listOf(Color(0xFF86EBFF), Color(0xFF1ABFF2))
+                )
+            }
+        },
         gradient400Secondary =
             Brush.verticalGradient(
                 colors = listOf(Color(0xFF8991FF), Color(0xFF6B75FF)),


### PR DESCRIPTION
## 📮 관련 이슈
- closed #15 

## 📌 작업 내용
- `Brush.linearGradient` 대신 `ShaderBrush`와 `LinearGradientShader`를 사용하여 정교한 그라데이션 좌표(Offset) 적용
- gradient900, gradient700, gradient400 색상에 대한 그라데이션 시작/끝 지점 커스텀 구현

## 📸 스크린샷
| AS-IS | TO-BE |
|:--:|:--:|
| <img width="597" height="107" alt="as-is" src="https://github.com/user-attachments/assets/d33b3848-55d3-4fe6-b556-32b2e9ce8a79" /> | <img width="592" height="109" alt="to-be" src="https://github.com/user-attachments/assets/58909cbd-b347-435d-a79a-ec01a63a7046" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

이번 업데이트는 내부 최적화에 집중한 변경사항으로, 사용자에게 보이는 기능 변화는 없습니다. 그래디언트 렌더링 로직이 개선되어 앱의 성능과 안정성이 향상되었습니다.

* **성능 개선**
  * 그래디언트 렌더링 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->