### PR TITLE
[Feat] 온보딩 프로필 - 닉네임 중복체크 API연동

### DIFF
--- a/app/src/main/java/com/flint/core/common/extension/sharedViewModel.kt
+++ b/app/src/main/java/com/flint/core/common/extension/sharedViewModel.kt
@@ -1,0 +1,22 @@
+package com.flint.core.common.extension
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavHostController
+
+/**
+ * 공용 뷰모델을 불러오기 위한 함수
+ * */
+@Composable
+inline fun <reified T : ViewModel> NavBackStackEntry.sharedViewModel(
+    navController: NavHostController,
+): T {
+    val navGraphRoute = destination.parent?.route ?: return hiltViewModel()
+    val parentEntry = remember(this) {
+        navController.getBackStackEntry(navGraphRoute)
+    }
+    return hiltViewModel(parentEntry)
+}

--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -15,6 +15,11 @@ interface Route {
     ) : Route
 
     @Serializable
+    data class OnboardingGraph(
+        val tempToken: String
+    ) : Route
+
+    @Serializable
     data object OnboardingContent : Route
 
     @Serializable

--- a/app/src/main/java/com/flint/data/api/UserApi.kt
+++ b/app/src/main/java/com/flint/data/api/UserApi.kt
@@ -1,14 +1,20 @@
 package com.flint.data.api
 
 import com.flint.data.dto.base.BaseResponse
+import com.flint.data.dto.user.response.NicknameCheckResponseDto
 import com.flint.data.dto.user.response.UserKeywordsResponseDto
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface UserApi {
     // 사용자 프로필 조회
 
     // 닉네임 중복 체크
+    @GET("/api/v1/users/nickname/check")
+    suspend fun checkNickname(
+        @Query("nickname") nickname: String
+    ): BaseResponse<NicknameCheckResponseDto>
 
     // 사용자 북마크 컬렉션 조회
 

--- a/app/src/main/java/com/flint/data/dto/user/response/NicknameCheckResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/user/response/NicknameCheckResponseDto.kt
@@ -1,0 +1,10 @@
+package com.flint.data.dto.user.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NicknameCheckResponseDto(
+    @SerialName("available")
+    val available: Boolean
+)

--- a/app/src/main/java/com/flint/domain/mapper/user/UserMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/user/UserMapper.kt
@@ -1,0 +1,10 @@
+package com.flint.domain.mapper.user
+
+import com.flint.data.dto.user.response.NicknameCheckResponseDto
+import com.flint.domain.model.user.NicknameCheckModel
+
+fun NicknameCheckResponseDto.toModel(): NicknameCheckModel {
+    return NicknameCheckModel(
+        isAvailable = this.available
+    )
+}

--- a/app/src/main/java/com/flint/domain/model/user/NicknameCheckModel.kt
+++ b/app/src/main/java/com/flint/domain/model/user/NicknameCheckModel.kt
@@ -1,0 +1,5 @@
+package com.flint.domain.model.user
+
+data class NicknameCheckModel(
+    val isAvailable: Boolean
+)

--- a/app/src/main/java/com/flint/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/UserRepository.kt
@@ -3,18 +3,26 @@ package com.flint.domain.repository
 import com.flint.core.common.util.suspendRunCatching
 import com.flint.data.api.UserApi
 import com.flint.domain.mapper.user.toModel
+import com.flint.domain.model.user.NicknameCheckModel
 import com.flint.domain.model.user.UserKeywordResponseModel
 import javax.inject.Inject
 
 class UserRepository
-    @Inject
-    constructor(
-        private val apiService: UserApi,
-    ) {
-        suspend fun getUserKeywords(userId: String): Result<List<UserKeywordResponseModel>> =
-            suspendRunCatching {
-                apiService.getUserKeywords(userId).data.keywords.map {
-                    it.toModel()
-                }
+@Inject
+constructor(
+    private val apiService: UserApi,
+) {
+
+    // 닉네임 중복 체크
+    suspend fun checkNickname(nickname: String): Result<NicknameCheckModel> =
+        suspendRunCatching {
+            apiService.checkNickname(nickname).data.toModel()
+        }
+
+    suspend fun getUserKeywords(userId: String): Result<List<UserKeywordResponseModel>> =
+        suspendRunCatching {
+            apiService.getUserKeywords(userId).data.keywords.map {
+                it.toModel()
             }
-    }
+        }
+}

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -62,9 +62,8 @@ fun OnboardingContentScreen(
         modifier =
             modifier
                 .fillMaxSize()
-                .background(color = FlintTheme.colors.background)
-                .statusBarsPadding(),
-    ) {
+                .background(color = FlintTheme.colors.background),
+        ) {
         FlintBackTopAppbar(
             onClick = onBackClick,
         )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.flint.core.designsystem.component.button.FlintBasicButton
 import com.flint.core.designsystem.component.button.FlintButtonState
 import com.flint.core.designsystem.component.image.SelectedContentItem
@@ -36,7 +37,8 @@ fun OnboardingContentRoute(
     paddingValues: PaddingValues,
     navigateToOnboardingOtt: () -> Unit,
     navigateUp: () -> Unit,
-) {
+    viewModel: OnboardingViewModel = hiltViewModel(),
+    ) {
     OnboardingContentScreen(
         nickname = "User",
         currentStep = 7,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.flint.R
 import com.flint.core.designsystem.component.button.FlintBasicButton
 import com.flint.core.designsystem.component.button.FlintButtonState
@@ -28,7 +29,8 @@ fun OnboardingDoneRoute(
     paddingValues: PaddingValues,
     navigateToHome: () -> Unit,
     navigateUp: () -> Unit,
-) {
+    viewModel: OnboardingViewModel = hiltViewModel(),
+    ) {
     OnboardingDoneScreen(
         onBackClick = navigateUp,
         onNextClick = navigateToHome,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
@@ -49,7 +49,6 @@ fun OnboardingDoneScreen(
             modifier
                 .fillMaxSize()
                 .background(color = FlintTheme.colors.background)
-                .statusBarsPadding(),
     ) {
         FlintBackTopAppbar(
             onClick = onBackClick,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingOttScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingOttScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.flint.core.designsystem.component.button.FlintBasicButton
 import com.flint.core.designsystem.component.button.FlintButtonState
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
@@ -30,7 +31,8 @@ fun OnboardingOttRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
     navigateToDone: () -> Unit,
-) {
+    viewModel: OnboardingViewModel = hiltViewModel(),
+    ) {
     // 뷰모델
     OnboardingOttScreen(
         nickname = "user",

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingOttScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingOttScreen.kt
@@ -54,7 +54,6 @@ fun OnboardingOttScreen(
             modifier
                 .fillMaxSize()
                 .background(color = FlintTheme.colors.background)
-                .statusBarsPadding(),
     ) {
         FlintBackTopAppbar(
             onClick = onBackClick,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingOttScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingOttScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -11,19 +11,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flint.core.designsystem.component.button.FlintBasicButton
 import com.flint.core.designsystem.component.button.FlintButtonState
 import com.flint.core.designsystem.component.image.ProfileImage
@@ -33,31 +28,32 @@ import com.flint.core.designsystem.theme.FlintTheme
 
 @Composable
 fun OnboardingProfileRoute(
+    viewModel: OnboardingViewModel,
     paddingValues: PaddingValues,
     navigateToOnboardingContent: () -> Unit,
     navigateUp: () -> Unit,
-    viewModel: OnboardingViewModel = hiltViewModel(),
-    ) {
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     OnboardingProfileScreen(
+        nickname = uiState.nickname,
+        isValid = uiState.isValid,
+        onNicknameChange = viewModel::updateNickname,
         onBackClick = navigateUp,
         onNextClick = navigateToOnboardingContent,
         modifier = Modifier.padding(paddingValues),
     )
 }
 
-private const val maxLength = 10
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OnboardingProfileScreen(
+    nickname: String,
+    isValid: Boolean,
+    onNicknameChange: (String) -> Unit,
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState()
-    var nickname by remember { mutableStateOf("") }
-
     Column(
         modifier =
             modifier
@@ -105,11 +101,11 @@ fun OnboardingProfileScreen(
                             .fillMaxHeight(),
                     placeholder = "닉네임",
                     value = nickname,
-                    maxLength = maxLength,
-                    onValueChange = { nickname = it },
+                    maxLength = OnboardingProfileUiState.MAX_LENGTH,
+                    onValueChange = onNicknameChange,
                     trailingContent = {
                         Text(
-                            text = "${nickname.length}/$maxLength",
+                            text = "${nickname.length}/${OnboardingProfileUiState.MAX_LENGTH}",
                             style = FlintTheme.typography.body1R16,
                             color = FlintTheme.colors.gray300,
                         )
@@ -118,7 +114,7 @@ fun OnboardingProfileScreen(
 
                 FlintBasicButton(
                     text = "확인",
-                    state = if (nickname.isNotEmpty()) FlintButtonState.Able else FlintButtonState.Disable,
+                    state = if (isValid) FlintButtonState.Able else FlintButtonState.Disable,
                     onClick = onNextClick,
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
                     modifier = Modifier.fillMaxHeight(),
@@ -128,7 +124,7 @@ fun OnboardingProfileScreen(
 
         FlintBasicButton(
             text = "시작하기",
-            state = if (nickname.isNotEmpty()) FlintButtonState.Able else FlintButtonState.Disable,
+            state = if (isValid) FlintButtonState.Able else FlintButtonState.Disable,
             onClick = onNextClick,
             contentPadding = PaddingValues(12.dp),
             modifier =
@@ -144,6 +140,9 @@ fun OnboardingProfileScreen(
 private fun OnboardingProfileScreenPreview() {
     FlintTheme {
         OnboardingProfileScreen(
+            nickname = "안비",
+            isValid = true,
+            onNicknameChange = {},
             onBackClick = {},
             onNextClick = {},
         )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.flint.core.designsystem.component.bottomsheet.MenuBottomSheet
 import com.flint.core.designsystem.component.bottomsheet.MenuBottomSheetData
 import com.flint.core.designsystem.component.button.FlintBasicButton
@@ -38,7 +39,8 @@ fun OnboardingProfileRoute(
     paddingValues: PaddingValues,
     navigateToOnboardingContent: () -> Unit,
     navigateUp: () -> Unit,
-) {
+    viewModel: OnboardingViewModel = hiltViewModel(),
+    ) {
     OnboardingProfileScreen(
         onBackClick = navigateUp,
         onNextClick = navigateToOnboardingContent,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -66,7 +66,6 @@ fun OnboardingProfileScreen(
             modifier
                 .fillMaxSize()
                 .background(color = FlintTheme.colors.background)
-                .statusBarsPadding(),
     ) {
         FlintBackTopAppbar(
             onClick = onBackClick,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -25,11 +24,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.flint.core.designsystem.component.bottomsheet.MenuBottomSheet
-import com.flint.core.designsystem.component.bottomsheet.MenuBottomSheetData
 import com.flint.core.designsystem.component.button.FlintBasicButton
 import com.flint.core.designsystem.component.button.FlintButtonState
-import com.flint.core.designsystem.component.image.EditProfileImage
+import com.flint.core.designsystem.component.image.ProfileImage
 import com.flint.core.designsystem.component.textfield.FlintBasicTextField
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
@@ -78,9 +75,8 @@ fun OnboardingProfileScreen(
                     .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            EditProfileImage(
+            ProfileImage(
                 imageUrl = "",
-                onEditClick = { showBottomSheet = true },
             )
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -139,25 +135,6 @@ fun OnboardingProfileScreen(
                 Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 20.dp),
-        )
-    }
-
-    if (showBottomSheet) {
-        MenuBottomSheet(
-            sheetState = sheetState,
-            onDismiss = { showBottomSheet = false },
-            menuBottomSheetDataList =
-                listOf(
-                    MenuBottomSheetData(
-                        label = "갤러리에서 선택",
-                        clickAction = { showBottomSheet = false },
-                    ),
-                    MenuBottomSheetData(
-                        label = "프로필 사진 삭제",
-                        color = FlintTheme.colors.error500,
-                        clickAction = { showBottomSheet = false },
-                    ),
-                ),
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -122,12 +122,9 @@ fun OnboardingProfileScreen(
 
                 FlintBasicButton(
                     text = "확인",
-                    state = when {
-                        !isValid -> FlintButtonState.Disable
-                        isNicknameAvailable == true -> FlintButtonState.Able
-                        else -> FlintButtonState.Able
-                    },
+                    state = if (isValid) FlintButtonState.Able else FlintButtonState.Disable,
                     onClick = onCheckNickname,
+                    enabled = isValid,
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
                     modifier = Modifier.fillMaxHeight(),
                 )
@@ -140,7 +137,8 @@ fun OnboardingProfileScreen(
         FlintBasicButton(
             text = "시작하기",
             state = if (canProceed) FlintButtonState.Able else FlintButtonState.Disable,
-            onClick = { if (canProceed) { onNextClick() } },
+            onClick = onNextClick,
+            enabled = canProceed,
             contentPadding = PaddingValues(12.dp),
             modifier =
                 Modifier

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -1,0 +1,10 @@
+package com.flint.presentation.onboarding
+
+data class OnboardingProfileUiState(
+    val nickname: String = "",
+    val isValid: Boolean = false,
+) {
+    companion object {
+        const val MAX_LENGTH = 10
+    }
+}

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -3,8 +3,14 @@ package com.flint.presentation.onboarding
 data class OnboardingProfileUiState(
     val nickname: String = "",
     val isValid: Boolean = false,
+    val isNicknameAvailable: Boolean? = null,
 ) {
     companion object {
-        const val MAX_LENGTH = 10
+        const val MAX_LENGTH = 8
+        const val MIN_LENGTH = 2
     }
+
+    //다믐단게 활성화
+    val canProceed: Boolean
+        get() = isValid && isNicknameAvailable == true
 }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -2,11 +2,35 @@ package com.flint.presentation.onboarding
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
 class OnboardingViewModel
-    @Inject
-    constructor() : ViewModel() {
-        // TODO: 비즈니스 로직 추가
+@Inject
+constructor() : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OnboardingProfileUiState())
+    val uiState: StateFlow<OnboardingProfileUiState> = _uiState.asStateFlow()
+
+    // ---------- onboarding profile ----------
+    fun updateNickname(nickname: String) {
+        if (nickname.length <= OnboardingProfileUiState.MAX_LENGTH) {
+            _uiState.update { currentState ->
+                currentState.copy(
+                    nickname = nickname,
+                    isValid = nickname.isNotEmpty()
+                )
+            }
+        }
     }
+
+    // ---------- onboarding contnet ----------
+
+    // ---------- onboarding ott ----------
+
+    // ---------- onboarding done ----------
+}

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -1,17 +1,21 @@
 package com.flint.presentation.onboarding
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.flint.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class OnboardingViewModel
-@Inject
-constructor() : ViewModel() {
+@Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OnboardingProfileUiState())
     val uiState: StateFlow<OnboardingProfileUiState> = _uiState.asStateFlow()
@@ -22,13 +26,28 @@ constructor() : ViewModel() {
             _uiState.update { currentState ->
                 currentState.copy(
                     nickname = nickname,
-                    isValid = nickname.isNotEmpty()
+                    isValid = nickname.length >= OnboardingProfileUiState.MIN_LENGTH,
+                    isNicknameAvailable = null,
                 )
             }
         }
     }
 
-    // ---------- onboarding contnet ----------
+    fun checkNicknameDuplication() {
+        val currentNickname = _uiState.value.nickname
+
+        viewModelScope.launch {
+            userRepository.checkNickname(currentNickname).onSuccess { result ->
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            isNicknameAvailable = result.isAvailable,
+                        )
+                    }
+                }
+        }
+    }
+
+    // ---------- onboarding content ----------
 
     // ---------- onboarding ott ----------
 

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -3,15 +3,19 @@ package com.flint.presentation.onboarding.navigation
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.flint.core.common.extension.sharedViewModel
 import com.flint.core.navigation.Route
-import com.flint.presentation.onboarding.OnboardingDoneRoute
 import com.flint.presentation.onboarding.OnboardingContentRoute
+import com.flint.presentation.onboarding.OnboardingDoneRoute
 import com.flint.presentation.onboarding.OnboardingOttRoute
 import com.flint.presentation.onboarding.OnboardingProfileRoute
+import com.flint.presentation.onboarding.OnboardingViewModel
 
 fun NavController.navigateToOnboarding(tempToken: String) {
-    navigate(Route.OnboardingProfile(tempToken))
+    navigate(Route.OnboardingGraph(tempToken))  // OnboardingGraph로 네비게이트
 }
 
 fun NavController.navigateToOnboardingContent() {
@@ -29,37 +33,53 @@ fun NavController.navigateToOnboardingDone() {
 fun NavGraphBuilder.onBoardingNavGraph(
     paddingValues: PaddingValues,
     onNavigateToHome: () -> Unit,
-    navController: NavController,
+    navController: NavHostController,
 ) {
-    composable<Route.OnboardingProfile> {
-        OnboardingProfileRoute(
-            paddingValues = paddingValues,
-            navigateUp = navController::navigateUp,
-            navigateToOnboardingContent = navController::navigateToOnboardingContent,
-        )
-    }
+    navigation<Route.OnboardingGraph>(
+        startDestination = Route.OnboardingProfile::class,
+    ) {
+        composable<Route.OnboardingProfile> { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
 
-    composable<Route.OnboardingContent> {
-        OnboardingContentRoute(
-            paddingValues = paddingValues,
-            navigateUp = navController::navigateUp,
-            navigateToOnboardingOtt = navController::navigateToOnboardingOtt,
-        )
-    }
+            OnboardingProfileRoute(
+                paddingValues = paddingValues,
+                navigateUp = navController::navigateUp,
+                navigateToOnboardingContent = navController::navigateToOnboardingContent,
+                viewModel = sharedViewModel,
+                )
+        }
 
-    composable<Route.OnboardingOtt> {
-        OnboardingOttRoute(
-            paddingValues = paddingValues,
-            navigateUp = navController::navigateUp,
-            navigateToDone = navController::navigateToOnboardingDone,
-        )
-    }
+        composable<Route.OnboardingContent> { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
 
-    composable<Route.OnboardingDone> {
-        OnboardingDoneRoute(
-            paddingValues = paddingValues,
-            navigateUp = navController::navigateUp,
-            navigateToHome = onNavigateToHome,
-        )
+            OnboardingContentRoute(
+                paddingValues = paddingValues,
+                navigateUp = navController::navigateUp,
+                navigateToOnboardingOtt = navController::navigateToOnboardingOtt,
+                viewModel = sharedViewModel,
+                )
+        }
+
+        composable<Route.OnboardingOtt> { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
+
+            OnboardingOttRoute(
+                paddingValues = paddingValues,
+                navigateUp = navController::navigateUp,
+                navigateToDone = navController::navigateToOnboardingDone,
+                viewModel = sharedViewModel,
+                )
+        }
+
+        composable<Route.OnboardingDone> { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
+
+            OnboardingDoneRoute(
+                paddingValues = paddingValues,
+                navigateUp = navController::navigateUp,
+                navigateToHome = onNavigateToHome,
+                viewModel = sharedViewModel,
+                )
+        }
     }
 }


### PR DESCRIPTION
## 📮 관련 이슈
- closed #141 

## 📌 작업 내용
- 온보딩 프로필 - 닉네임 중복체크

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <video width="360" src="https://github.com/user-attachments/assets/81d42832-c659-4ec2-89a9-62e2e0ed5a70" /> |

## 😅 미구현
- [ ] 닉네임 유효성검사(특수문자,이모지)
- [ ] 토스트 (닉네임 중복검사 완료/실패/유효성)
