### PR TITLE
[Feat/#157] 프로필 추가 로직 구현

### DIFF
--- a/app/src/main/java/com/flint/core/navigation/MainTabRoute.kt
+++ b/app/src/main/java/com/flint/core/navigation/MainTabRoute.kt
@@ -10,7 +10,5 @@ interface MainTabRoute : Route {
     data object Explore : MainTabRoute
 
     @Serializable
-    data class Profile(
-        val userId: String? = null,
-    ) : MainTabRoute
+    data object Profile : MainTabRoute
 }

--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -47,4 +47,9 @@ interface Route {
 
     @Serializable
     data object AddContent : Route
+
+    @Serializable
+    data class Profile(
+        val userId: String? = null,
+    ) : Route
 }

--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -32,6 +32,7 @@ interface Route {
     @Serializable
     data class CollectionList(
         val routeType: CollectionListRouteType,
+        val userId: String? = null
     ) : Route
 
     @Serializable

--- a/app/src/main/java/com/flint/data/api/ContentApi.kt
+++ b/app/src/main/java/com/flint/data/api/ContentApi.kt
@@ -11,12 +11,6 @@ interface ContentApi {
     @GET("/api/v1/contents/bookmarks")
     suspend fun getBookmarkedContentList(): BaseResponse<BookmarkedContentListResponseDto>
 
-    // 사용자별 북마크한 콘텐츠 목록 조회
-    @GET("/api/v1/contents/{userId}/bookmarked-contents")
-    suspend fun getBookmarkedContentListByUserId(
-        @Path("userId") userId: String
-    ): BaseResponse<BookmarkedContentListResponseDto>
-
     // 콘텐츠별 OTT 목록 조회
     @GET("/api/v1/contents/ott/{contentId}")
     suspend fun getOttListPerContent(

--- a/app/src/main/java/com/flint/data/api/ContentApi.kt
+++ b/app/src/main/java/com/flint/data/api/ContentApi.kt
@@ -11,6 +11,12 @@ interface ContentApi {
     @GET("/api/v1/contents/bookmarks")
     suspend fun getBookmarkedContentList(): BaseResponse<BookmarkedContentListResponseDto>
 
+    // 사용자별 북마크한 콘텐츠 목록 조회
+    @GET("/api/v1/contents/{userId}/bookmarked-contents")
+    suspend fun getBookmarkedContentListByUserId(
+        @Path("userId") userId: String
+    ): BaseResponse<BookmarkedContentListResponseDto>
+
     // 콘텐츠별 OTT 목록 조회
     @GET("/api/v1/contents/ott/{contentId}")
     suspend fun getOttListPerContent(

--- a/app/src/main/java/com/flint/data/api/UserApi.kt
+++ b/app/src/main/java/com/flint/data/api/UserApi.kt
@@ -42,6 +42,14 @@ interface UserApi {
         @Path("userId") userId: String,
     ): BaseResponse<CreatedCollectionListResponseDto>
 
+    // 내 북마크 컬렉션 조회
+    @GET("/api/v1/users/me/bookmarked-collections")
+    suspend fun getMyBookmarkedCollections(): BaseResponse<BookmarkedCollectionListResponseDto>
+
+    // 내 컬렉션 조회
+    @GET("/api/v1/users/me/collections")
+    suspend fun getMyCreatedCollections(): BaseResponse<CreatedCollectionListResponseDto>
+
     // 사용자 취향 키워드 조회
     @GET("/api/v1/users/{userId}/keywords")
     suspend fun getUserKeywords(

--- a/app/src/main/java/com/flint/data/api/UserApi.kt
+++ b/app/src/main/java/com/flint/data/api/UserApi.kt
@@ -1,6 +1,7 @@
 package com.flint.data.api
 
 import com.flint.data.dto.base.BaseResponse
+import com.flint.data.dto.content.response.BookmarkedContentListResponseDto
 import com.flint.data.dto.user.response.NicknameCheckResponseDto
 import com.flint.data.dto.user.response.BookmarkedCollectionListResponseDto
 import com.flint.data.dto.user.response.CreatedCollectionListResponseDto
@@ -28,6 +29,12 @@ interface UserApi {
     suspend fun getUserBookmarkedCollections(
         @Path("userId") userId: String,
     ): BaseResponse<BookmarkedCollectionListResponseDto>
+
+    // 사용자별 북마크한 콘텐츠 목록 조회
+    @GET("/api/v1/contents/{userId}/bookmarked-contents")
+    suspend fun getBookmarkedContentListByUserId(
+        @Path("userId") userId: String
+    ): BaseResponse<BookmarkedContentListResponseDto>
 
     // 사용자 생성 컬렉션 조회
     @GET("/api/v1/users/{userId}/collections")

--- a/app/src/main/java/com/flint/data/di/interceptor/TokenInterceptor.kt
+++ b/app/src/main/java/com/flint/data/di/interceptor/TokenInterceptor.kt
@@ -26,8 +26,6 @@ class TokenInterceptor
             if (accessToken.isNotEmpty()) {
                 requestBuilder.header("Authorization", "Bearer $accessToken")
             }
-            // sample
-            requestBuilder.header("Authorization", "Bearer eyJhbGciOiJIUzUxMiJ9.eyJ1c2VySWQiOjgwMDAyMTcxMTM1NzExODE5MSwicm9sZSI6IkZMSU5HIiwidHlwZSI6IkFDQ0VTUyIsImlhdCI6MTc2ODgzODU0MCwiZXhwIjoxNzcwMDQ4MTQwfQ.A2XYyu24IoGAXNSQHJ1S-iudWmg8II2_ivI4EdyyWw9KS9oJlxHKOAhcKrsLpLkc9kllZyxwaTJO1t4vI7oZlg")
 
             val request = requestBuilder.build()
 

--- a/app/src/main/java/com/flint/data/dto/auth/response/SocialVerifyResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/auth/response/SocialVerifyResponseDto.kt
@@ -12,9 +12,9 @@ data class SocialVerifyResponseDto(
     @SerialName("refreshToken")
     val refreshToken: String? = null,
     @SerialName("userId")
-    val userId: Long? = null,
-    @SerialName("nickName")
-    val nickName: String? = null,
+    val userId: String? = null,
+    @SerialName("nickname")
+    val nickname: String? = null,
     @SerialName("tempToken")
     val tempToken: String? = null,
 )

--- a/app/src/main/java/com/flint/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/flint/data/local/PreferencesManager.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,11 +37,5 @@ class PreferencesManager @Inject constructor(
         dataStore.edit { preferences ->
             preferences.clear()
         }
-    }
-
-    suspend fun getUserId(): String {
-        return dataStore.data.map { preferences ->
-            preferences[stringPreferencesKey("USER_ID")] ?: ""
-        }.first()
     }
 }

--- a/app/src/main/java/com/flint/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/flint/data/local/PreferencesManager.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -37,5 +38,11 @@ class PreferencesManager @Inject constructor(
         dataStore.edit { preferences ->
             preferences.clear()
         }
+    }
+
+    suspend fun getUserId(): String {
+        return dataStore.data.map { preferences ->
+            preferences[stringPreferencesKey("USER_ID")] ?: ""
+        }.first()
     }
 }

--- a/app/src/main/java/com/flint/domain/mapper/auth/SocialVerifyMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/auth/SocialVerifyMapper.kt
@@ -17,6 +17,6 @@ fun SocialVerifyResponseDto.toModel(): SocialVerifyResponseModel =
         accessToken = accessToken,
         refreshToken = refreshToken,
         userId = userId,
-        nickName = nickName,
+        nickName = nickname,
         tempToken = tempToken,
     )

--- a/app/src/main/java/com/flint/domain/model/auth/SocialVerifyModel.kt
+++ b/app/src/main/java/com/flint/domain/model/auth/SocialVerifyModel.kt
@@ -11,7 +11,7 @@ data class SocialVerifyResponseModel(
     val isRegistered: Boolean,
     val accessToken: String?,
     val refreshToken: String?,
-    val userId: Long?,
+    val userId: String?,
     val nickName: String?,
     val tempToken: String?,
 )

--- a/app/src/main/java/com/flint/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/AuthRepository.kt
@@ -12,7 +12,6 @@ import com.flint.domain.model.auth.SignupRequestModel
 import com.flint.domain.model.auth.SignupResponseModel
 import com.flint.domain.model.auth.SocialVerifyRequestModel
 import com.flint.domain.model.auth.SocialVerifyResponseModel
-import timber.log.Timber
 import javax.inject.Inject
 
 class AuthRepository @Inject constructor(
@@ -22,13 +21,13 @@ class AuthRepository @Inject constructor(
     suspend fun signup(model: SignupRequestModel): Result<SignupResponseModel> =
         suspendRunCatching { api.signup(model.toDto()).data.toModel() }
 
-    suspend fun socialVerify(model: SocialVerifyRequestModel): Result<SocialVerifyResponseModel> {
-        val result = api.socialVerify(model.toDto()).data.toModel()
-        preferencesManager.saveString(ACCESS_TOKEN, result.accessToken.toString())
-        preferencesManager.saveString(USER_NAME, result.nickName.toString())
-        preferencesManager.saveString(USER_ID, result.userId.toString())
-
-        return suspendRunCatching { result }
-    }
+    suspend fun socialVerify(model: SocialVerifyRequestModel): Result<SocialVerifyResponseModel> =
+        suspendRunCatching {
+            val result = api.socialVerify(model.toDto()).data.toModel()
+            result.accessToken?.let { preferencesManager.saveString(ACCESS_TOKEN, it) }
+            result.userId?.let { preferencesManager.saveString(USER_ID, it) }
+            result.nickName?.let { preferencesManager.saveString(USER_NAME, it) }
+            result
+        }
 
 }

--- a/app/src/main/java/com/flint/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/AuthRepository.kt
@@ -1,5 +1,7 @@
 package com.flint.domain.repository
 
+import com.flint.core.common.util.DataStoreKey.ACCESS_TOKEN
+import com.flint.core.common.util.DataStoreKey.USER_ID
 import com.flint.data.local.PreferencesManager
 import com.flint.core.common.util.DataStoreKey.USER_NAME
 import com.flint.core.common.util.suspendRunCatching
@@ -10,6 +12,7 @@ import com.flint.domain.model.auth.SignupRequestModel
 import com.flint.domain.model.auth.SignupResponseModel
 import com.flint.domain.model.auth.SocialVerifyRequestModel
 import com.flint.domain.model.auth.SocialVerifyResponseModel
+import timber.log.Timber
 import javax.inject.Inject
 
 class AuthRepository @Inject constructor(
@@ -21,7 +24,9 @@ class AuthRepository @Inject constructor(
 
     suspend fun socialVerify(model: SocialVerifyRequestModel): Result<SocialVerifyResponseModel> {
         val result = api.socialVerify(model.toDto()).data.toModel()
+        preferencesManager.saveString(ACCESS_TOKEN, result.accessToken.toString())
         preferencesManager.saveString(USER_NAME, result.nickName.toString())
+        preferencesManager.saveString(USER_ID, result.userId.toString())
 
         return suspendRunCatching { result }
     }

--- a/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
@@ -1,17 +1,22 @@
 package com.flint.domain.repository
 
+import com.flint.core.common.util.DataStoreKey.USER_ID
 import com.flint.core.common.util.suspendRunCatching
 import com.flint.data.api.ContentApi
+import com.flint.data.local.PreferencesManager
 import com.flint.domain.mapper.content.toModel
 import com.flint.domain.mapper.ott.toModel
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.ott.OttListModel
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
 import javax.inject.Inject
 
 class ContentRepository @Inject constructor(
     private val apiService: ContentApi,
+    private val preferencesManager: PreferencesManager,
 ) {
-    private val myTempUserId = "801159854933808613" // TODO: 토큰 userId
+    private suspend fun myUserId(): String = preferencesManager.getString(USER_ID).first()
 
     // 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentList() : Result<BookmarkedContentListModel> =
@@ -19,7 +24,9 @@ class ContentRepository @Inject constructor(
 
     // 사용자별 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentListByUserId(userId: String?) : Result<BookmarkedContentListModel> =
-        suspendRunCatching { apiService.getBookmarkedContentListByUserId(userId ?: myTempUserId).data.toModel() }
+        suspendRunCatching {
+            Timber.d("userId in getBookmarkedContentListByUserId: ${userId ?: myUserId()}")
+            apiService.getBookmarkedContentListByUserId(userId ?: myUserId()).data.toModel() }
 
     // 콘텐츠별 OTT 목록 조회
     suspend fun getOttListPerContent(contentId: String) : Result<OttListModel> =

--- a/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
@@ -11,9 +11,15 @@ import javax.inject.Inject
 class ContentRepository @Inject constructor(
     private val apiService: ContentApi,
 ) {
+    private val myTempUserId = "801159854933808613" // TODO: 토큰 userId
+
     // 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentList() : Result<BookmarkedContentListModel> =
         suspendRunCatching { apiService.getBookmarkedContentList().data.toModel() }
+
+    // 사용자별 북마크한 콘텐츠 목록 조회
+    suspend fun getBookmarkedContentListByUserId(userId: String?) : Result<BookmarkedContentListModel> =
+        suspendRunCatching { apiService.getBookmarkedContentListByUserId(userId ?: myTempUserId).data.toModel() }
 
     // 콘텐츠별 OTT 목록 조회
     suspend fun getOttListPerContent(contentId: String) : Result<OttListModel> =

--- a/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
@@ -13,13 +13,8 @@ import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class ContentRepository @Inject constructor(
-    private val apiService: ContentApi,
-    private val preferencesManager: PreferencesManager,
+    private val apiService: ContentApi
 ) {
-    private fun myUserId(): String = runBlocking {
-        preferencesManager.getString(USER_ID).first()
-    }
-
     // 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentList() : Result<BookmarkedContentListModel> =
         suspendRunCatching { apiService.getBookmarkedContentList().data.toModel() }

--- a/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
@@ -9,11 +9,8 @@ import com.flint.domain.mapper.ott.toModel
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.ott.OttListModel
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import timber.log.Timber
 import javax.inject.Inject
-import kotlin.text.first
 
 class ContentRepository @Inject constructor(
     private val apiService: ContentApi,
@@ -26,15 +23,6 @@ class ContentRepository @Inject constructor(
     // 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentList() : Result<BookmarkedContentListModel> =
         suspendRunCatching { apiService.getBookmarkedContentList().data.toModel() }
-
-    // 사용자별 북마크한 콘텐츠 목록 조회
-    suspend fun getBookmarkedContentListByUserId(userId: String?) : Result<BookmarkedContentListModel> =
-        suspendRunCatching {
-//            val myUserId = runBlocking {
-//                myUserId()
-//            }
-            Timber.d("userId in getBookmarkedContentListByUserId: ${userId ?: myUserId()}")
-            apiService.getBookmarkedContentListByUserId(userId ?: "801159854933808613").data.toModel() }
 
     // 콘텐츠별 OTT 목록 조회
     suspend fun getOttListPerContent(contentId: String) : Result<OttListModel> =

--- a/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
@@ -9,14 +9,19 @@ import com.flint.domain.mapper.ott.toModel
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.ott.OttListModel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.text.first
 
 class ContentRepository @Inject constructor(
     private val apiService: ContentApi,
     private val preferencesManager: PreferencesManager,
 ) {
-    private suspend fun myUserId(): String = preferencesManager.getString(USER_ID).first()
+    private fun myUserId(): String = runBlocking {
+        preferencesManager.getString(USER_ID).first()
+    }
 
     // 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentList() : Result<BookmarkedContentListModel> =
@@ -25,8 +30,11 @@ class ContentRepository @Inject constructor(
     // 사용자별 북마크한 콘텐츠 목록 조회
     suspend fun getBookmarkedContentListByUserId(userId: String?) : Result<BookmarkedContentListModel> =
         suspendRunCatching {
+//            val myUserId = runBlocking {
+//                myUserId()
+//            }
             Timber.d("userId in getBookmarkedContentListByUserId: ${userId ?: myUserId()}")
-            apiService.getBookmarkedContentListByUserId(userId ?: myUserId()).data.toModel() }
+            apiService.getBookmarkedContentListByUserId(userId ?: "801159854933808613").data.toModel() }
 
     // 콘텐츠별 OTT 목록 조회
     suspend fun getOttListPerContent(contentId: String) : Result<OttListModel> =

--- a/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ContentRepository.kt
@@ -1,15 +1,11 @@
 package com.flint.domain.repository
 
-import com.flint.core.common.util.DataStoreKey.USER_ID
 import com.flint.core.common.util.suspendRunCatching
 import com.flint.data.api.ContentApi
-import com.flint.data.local.PreferencesManager
 import com.flint.domain.mapper.content.toModel
 import com.flint.domain.mapper.ott.toModel
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.ott.OttListModel
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class ContentRepository @Inject constructor(

--- a/app/src/main/java/com/flint/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/UserRepository.kt
@@ -24,24 +24,36 @@ class UserRepository @Inject constructor(
         preferencesManager.getString(USER_ID).first()
     }
 
+    // 사용자 프로필 조회
     suspend fun getUserProfile(userId: String?): Result<UserProfileResponseModel> =
         suspendRunCatching {
             apiService.getUserProfile(userId ?: myUserId()).data.toModel()
         }
 
+    // 사용자 취향 키워드 조회
     suspend fun getUserKeywords(userId: String?): Result<KeywordListModel> =
         suspendRunCatching {
             apiService.getUserKeywords(userId ?: myUserId()).data.toModel()
         }
 
+    // 사용자별 생성한 컬렉션 목록 조회
     suspend fun getUserCreatedCollections(userId: String?): Result<CollectionListModel> =
         suspendRunCatching {
-            apiService.getUserCreatedCollections(userId ?: myUserId()).data.toModel()
+            if (userId == null) {
+                apiService.getMyCreatedCollections().data.toModel()
+            } else {
+                apiService.getUserCreatedCollections(userId).data.toModel()
+            }
         }
 
+    // 사용자별 북마크한 컬렉션 목록 조회
     suspend fun getUserBookmarkedCollections(userId: String?): Result<CollectionListModel> =
         suspendRunCatching {
-            apiService.getUserBookmarkedCollections(userId ?: myUserId()).data.toModel()
+            if (userId == null) {
+                apiService.getMyBookmarkedCollections().data.toModel()
+            } else {
+                apiService.getUserBookmarkedCollections(userId).data.toModel()
+            }
         }
 
     // 사용자별 북마크한 콘텐츠 목록 조회

--- a/app/src/main/java/com/flint/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/UserRepository.kt
@@ -5,9 +5,11 @@ import com.flint.core.common.util.suspendRunCatching
 import com.flint.data.api.UserApi
 import com.flint.data.local.PreferencesManager
 import com.flint.domain.mapper.collection.toModel
+import com.flint.domain.mapper.content.toModel
 import com.flint.domain.mapper.user.toModel
 import com.flint.domain.model.user.NicknameCheckModel
 import com.flint.domain.model.collection.CollectionListModel
+import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.user.KeywordListModel
 import com.flint.domain.model.user.UserProfileResponseModel
 import kotlinx.coroutines.flow.first
@@ -41,6 +43,10 @@ class UserRepository @Inject constructor(
         suspendRunCatching {
             apiService.getUserBookmarkedCollections(userId ?: myUserId()).data.toModel()
         }
+
+    // 사용자별 북마크한 콘텐츠 목록 조회
+    suspend fun getUserBookmarkedContents(userId: String?) : Result<BookmarkedContentListModel> =
+        suspendRunCatching { apiService.getBookmarkedContentListByUserId(userId ?: myUserId()).data.toModel() }
 
     // 닉네임 중복 체크
     suspend fun checkNickname(nickname: String): Result<NicknameCheckModel> =

--- a/app/src/main/java/com/flint/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/UserRepository.kt
@@ -1,38 +1,42 @@
 package com.flint.domain.repository
 
+import com.flint.core.common.util.DataStoreKey.USER_ID
 import com.flint.core.common.util.suspendRunCatching
 import com.flint.data.api.UserApi
+import com.flint.data.local.PreferencesManager
 import com.flint.domain.mapper.collection.toModel
 import com.flint.domain.mapper.user.toModel
 import com.flint.domain.model.user.NicknameCheckModel
 import com.flint.domain.model.collection.CollectionListModel
 import com.flint.domain.model.user.KeywordListModel
 import com.flint.domain.model.user.UserProfileResponseModel
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class UserRepository @Inject constructor(
     private val apiService: UserApi,
+    private val preferencesManager: PreferencesManager,
 ) {
-    private val myTempUserId = "801159854933808613" //TODO: 토큰 userId
+    private suspend fun myUserId(): String = preferencesManager.getString(USER_ID).first()
 
     suspend fun getUserProfile(userId: String?): Result<UserProfileResponseModel> =
         suspendRunCatching {
-            apiService.getUserProfile(userId ?: myTempUserId).data.toModel()
+            apiService.getUserProfile(userId ?: myUserId()).data.toModel()
         }
 
     suspend fun getUserKeywords(userId: String?): Result<KeywordListModel> =
         suspendRunCatching {
-            apiService.getUserKeywords(userId ?: myTempUserId).data.toModel()
+            apiService.getUserKeywords(userId ?: myUserId()).data.toModel()
         }
 
     suspend fun getUserCreatedCollections(userId: String?): Result<CollectionListModel> =
         suspendRunCatching {
-            apiService.getUserCreatedCollections(userId ?: myTempUserId).data.toModel()
+            apiService.getUserCreatedCollections(userId ?: myUserId()).data.toModel()
         }
 
     suspend fun getUserBookmarkedCollections(userId: String?): Result<CollectionListModel> =
         suspendRunCatching {
-            apiService.getUserBookmarkedCollections(userId ?: myTempUserId).data.toModel()
+            apiService.getUserBookmarkedCollections(userId ?: myUserId()).data.toModel()
         }
 
     // 닉네임 중복 체크

--- a/app/src/main/java/com/flint/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/UserRepository.kt
@@ -11,13 +11,16 @@ import com.flint.domain.model.collection.CollectionListModel
 import com.flint.domain.model.user.KeywordListModel
 import com.flint.domain.model.user.UserProfileResponseModel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class UserRepository @Inject constructor(
     private val apiService: UserApi,
     private val preferencesManager: PreferencesManager,
 ) {
-    private suspend fun myUserId(): String = preferencesManager.getString(USER_ID).first()
+    private fun myUserId(): String = runBlocking {
+        preferencesManager.getString(USER_ID).first()
+    }
 
     suspend fun getUserProfile(userId: String?): Result<UserProfileResponseModel> =
         suspendRunCatching {

--- a/app/src/main/java/com/flint/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/UserRepository.kt
@@ -7,21 +7,20 @@ import com.flint.data.local.PreferencesManager
 import com.flint.domain.mapper.collection.toModel
 import com.flint.domain.mapper.content.toModel
 import com.flint.domain.mapper.user.toModel
-import com.flint.domain.model.user.NicknameCheckModel
 import com.flint.domain.model.collection.CollectionListModel
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.user.KeywordListModel
+import com.flint.domain.model.user.NicknameCheckModel
 import com.flint.domain.model.user.UserProfileResponseModel
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class UserRepository @Inject constructor(
     private val apiService: UserApi,
     private val preferencesManager: PreferencesManager,
 ) {
-    private fun myUserId(): String = runBlocking {
-        preferencesManager.getString(USER_ID).first()
+    private suspend fun myUserId(): String {
+        return preferencesManager.getString(USER_ID).first()
     }
 
     // 사용자 프로필 조회

--- a/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
@@ -118,6 +118,7 @@ fun CollectionDetailRoute(
                 navigateUp = navigateUp,
                 onBookmarkIconClick = viewModel::toggleContentBookmark,
                 onSpoilClick = viewModel::spoil,
+                onAuthorNicknameClick = { navigateToProfile(collectionDetail.author.id) },
                 onAuthorClick = navigateToProfile,
             )
         }
@@ -222,6 +223,7 @@ fun CollectionDetailScreen(
     navigateUp: () -> Unit,
     onBookmarkIconClick: (String) -> Unit,
     onSpoilClick: (String) -> Unit,
+    onAuthorNicknameClick: () -> Unit,
     onAuthorClick: (authorId: String) -> Unit,
 ) {
     CompositionLocalProvider(
@@ -296,6 +298,7 @@ fun CollectionDetailScreen(
                         authorUserRoleType = authorUserRoleType,
                         createdAt = createdAt,
                         collectionContent = description,
+                        onAuthorNicknameClick = onAuthorNicknameClick,
                         modifier =
                             Modifier
                                 .fillMaxWidth()
@@ -571,6 +574,7 @@ private fun CollectionDetailDescription(
     authorUserRoleType: UserRoleType,
     createdAt: String,
     collectionContent: String,
+    onAuthorNicknameClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -585,6 +589,9 @@ private fun CollectionDetailDescription(
                 text = authorNickname,
                 color = FlintTheme.colors.white,
                 style = FlintTheme.typography.head2Sb20,
+                modifier = Modifier.noRippleClickable(
+                    onClick = { onAuthorNicknameClick() }
+                )
             )
 
             if (authorUserRoleType == UserRoleType.FLINER) {
@@ -839,6 +846,7 @@ private fun CollectionDetailDescriptionPreview(
             authorUserRoleType = data.authorUserRoleType,
             createdAt = data.createdAt,
             collectionContent = data.collectionContent,
+            onAuthorNicknameClick = {}
         )
     }
 }
@@ -999,7 +1007,8 @@ private fun CollectionDetailScreenPreview(
                 navigateUp = {},
                 onBookmarkIconClick = {},
                 onSpoilClick = {},
-                onAuthorClick = {}
+                onAuthorClick = {},
+                onAuthorNicknameClick = {}
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
@@ -53,7 +53,7 @@ fun CollectionListRoute(
 
     CollectionListScreen(
         modifier = Modifier.padding(paddingValues),
-        title = viewModel.routeType.title,
+        title = viewModel.routeReceiveData.routeType.title,
         onBackClick = navigateUp,
         onCollectionItemClick = navigateToCollectionDetail,
         onBookmarkClick = viewModel::toggleCollectionBookmark,

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListScreen.kt
@@ -53,7 +53,7 @@ fun CollectionListRoute(
 
     CollectionListScreen(
         modifier = Modifier.padding(paddingValues),
-        title = viewModel.routeReceiveData.routeType.title,
+        title = uiState.appbarTitle,
         onBackClick = navigateUp,
         onCollectionItemClick = navigateToCollectionDetail,
         onBookmarkClick = viewModel::toggleCollectionBookmark,

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListViewModel.kt
@@ -15,6 +15,8 @@ import com.flint.presentation.collectionlist.sideeffect.CollectionListSideEffect
 import com.flint.presentation.collectionlist.uistate.CollectionListUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -40,6 +42,10 @@ class CollectionListViewModel @Inject constructor(
     private val _sideEffect: MutableSharedFlow<CollectionListSideEffect> = MutableSharedFlow()
     val sideEffect: SharedFlow<CollectionListSideEffect> = _sideEffect.asSharedFlow()
 
+    private val debounceDelayMs: Long = 500L
+    private val collectionBookmarkDebounceJobs: MutableMap<String, Job> = mutableMapOf()
+    private val initialCollectionBookmarkStates: MutableMap<String, Boolean> = mutableMapOf()
+
     init {
         getCollectionList()
     }
@@ -63,42 +69,113 @@ class CollectionListViewModel @Inject constructor(
     }
 
     fun toggleCollectionBookmark(collectionId: String) {
-        viewModelScope.launch {
-            bookmarkRepository.toggleCollectionBookmark(collectionId)
-                .onSuccess { isBookmarked: Boolean ->
-                    _uiState.update { currentState: CollectionListUiState ->
-                        val collectionList = currentState.collectionList
-                        if (collectionList !is UiState.Success) return@update currentState
+        val collectionList = (_uiState.value.collectionList as? UiState.Success)?.data ?: return
+        val targetCollection = collectionList.collections.find { it.id == collectionId } ?: return
 
-                        val updatedCollections = collectionList.data.collections.map { collection ->
-                            if (collection.id == collectionId) {
-                                collection.copy(
-                                    isBookmarked = isBookmarked,
-                                    bookmarkCount = if (isBookmarked) {
-                                        collection.bookmarkCount + 1
-                                    } else {
-                                        collection.bookmarkCount - 1
-                                    }
-                                )
-                            } else {
-                                collection
-                            }
-                        }.toImmutableList()
+        if (initialCollectionBookmarkStates[collectionId] == null) {
+            initialCollectionBookmarkStates[collectionId] = targetCollection.isBookmarked
+        }
 
-                        currentState.copy(
-                            collectionList = UiState.Success(
-                                CollectionListModel(collections = updatedCollections)
-                            )
+        val newBookmarkState = !targetCollection.isBookmarked
+        val initialBookmarkCount = targetCollection.bookmarkCount
+        val adjustedBookmarkCount =
+            if (newBookmarkState) initialBookmarkCount + 1
+            else (initialBookmarkCount - 1).coerceAtLeast(0)
+
+        updateCollectionBookmarkState(
+            collectionId = collectionId,
+            isBookmarked = newBookmarkState,
+            bookmarkCount = adjustedBookmarkCount
+        )
+
+        collectionBookmarkDebounceJobs[collectionId]?.cancel()
+        collectionBookmarkDebounceJobs[collectionId] = viewModelScope.launch {
+            delay(debounceDelayMs)
+
+            val currentCollection = (_uiState.value.collectionList as? UiState.Success)?.data
+                ?.collections?.find { it.id == collectionId } ?: return@launch
+
+            val initialState = initialCollectionBookmarkStates[collectionId] ?: return@launch
+
+            if (currentCollection.isBookmarked != initialState) {
+                bookmarkRepository.toggleCollectionBookmark(collectionId)
+                    .onSuccess { isBookmarked: Boolean ->
+                        updateCollectionIsBookmarkedOnly(
+                            collectionId = collectionId,
+                            isBookmarked = isBookmarked
+                        )
+                        _sideEffect.emit(
+                            CollectionListSideEffect.ToggleCollectionBookmarkSuccess(isBookmarked)
                         )
                     }
+                    .onFailure {
+                        val fallbackCollection = (_uiState.value.collectionList as? UiState.Success)
+                            ?.data?.collections?.find { it.id == collectionId } ?: return@onFailure
 
-                    _sideEffect.emit(
-                        CollectionListSideEffect.ToggleCollectionBookmarkSuccess(isBookmarked)
+                        val rollbackCount =
+                            if (initialState) fallbackCollection.bookmarkCount + 1
+                            else (fallbackCollection.bookmarkCount - 1).coerceAtLeast(0)
+
+                        updateCollectionBookmarkState(
+                            collectionId = collectionId,
+                            isBookmarked = initialState,
+                            bookmarkCount = rollbackCount
+                        )
+                        _sideEffect.emit(CollectionListSideEffect.ToggleCollectionBookmarkFailure)
+                    }
+            }
+
+            initialCollectionBookmarkStates.remove(collectionId)
+            collectionBookmarkDebounceJobs.remove(collectionId)
+        }
+    }
+
+    private fun updateCollectionBookmarkState(
+        collectionId: String,
+        isBookmarked: Boolean,
+        bookmarkCount: Int,
+    ) {
+        _uiState.update { currentState: CollectionListUiState ->
+            val collectionList = currentState.collectionList
+            if (collectionList !is UiState.Success) return@update currentState
+
+            val updatedCollections = collectionList.data.collections.map { collection ->
+                if (collection.id == collectionId) {
+                    collection.copy(
+                        isBookmarked = isBookmarked,
+                        bookmarkCount = bookmarkCount
                     )
+                } else {
+                    collection
                 }
-                .onFailure {
-                    _sideEffect.emit(CollectionListSideEffect.ToggleCollectionBookmarkFailure)
+            }.toImmutableList()
+
+            currentState.copy(
+                collectionList = UiState.Success(
+                    CollectionListModel(collections = updatedCollections)
+                )
+            )
+        }
+    }
+
+    private fun updateCollectionIsBookmarkedOnly(collectionId: String, isBookmarked: Boolean) {
+        _uiState.update { currentState: CollectionListUiState ->
+            val collectionList = currentState.collectionList
+            if (collectionList !is UiState.Success) return@update currentState
+
+            val updatedCollections = collectionList.data.collections.map { collection ->
+                if (collection.id == collectionId) {
+                    collection.copy(isBookmarked = isBookmarked)
+                } else {
+                    collection
                 }
+            }.toImmutableList()
+
+            currentState.copy(
+                collectionList = UiState.Success(
+                    CollectionListModel(collections = updatedCollections)
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListViewModel.kt
@@ -33,9 +33,6 @@ class CollectionListViewModel @Inject constructor(
     private val collectionRepository: CollectionRepository,
     private val bookmarkRepository: BookmarkRepository,
 ) : ViewModel() {
-
-    val routeReceiveData = savedStateHandle.toRoute<Route.CollectionList>()
-
     private val _uiState = MutableStateFlow<CollectionListUiState>(CollectionListUiState())
     val uiState: StateFlow<CollectionListUiState> = _uiState
 
@@ -47,19 +44,23 @@ class CollectionListViewModel @Inject constructor(
     private val initialCollectionBookmarkStates: MutableMap<String, Boolean> = mutableMapOf()
 
     init {
-        getCollectionList()
+        val routeReceiveData = savedStateHandle.toRoute<Route.CollectionList>()
+        setAppBarTitle(routeReceiveData.routeType.title)
+        getCollectionList(routeReceiveData)
     }
 
-    private fun getCollectionList() {
-        val userId = routeReceiveData.userId
+    private fun setAppBarTitle(title: String) {
+        _uiState.update { it.copy(appbarTitle = title) }
+    }
 
+    private fun getCollectionList(data: Route.CollectionList) {
         viewModelScope.launch {
             _uiState.update { it.copy(collectionList = UiState.Loading) }
 
-            when (routeReceiveData.routeType) {
-                CollectionListRouteType.CREATED -> userRepository.getUserCreatedCollections(userId = userId)
-                CollectionListRouteType.SAVED -> userRepository.getUserBookmarkedCollections(userId = userId)
-                CollectionListRouteType.RECENT -> collectionRepository.getRecentCollectionList()
+            when (data.routeType) {
+                CollectionListRouteType.CREATED -> userRepository.getUserCreatedCollections(userId = data.userId)
+                CollectionListRouteType.SAVED -> userRepository.getUserBookmarkedCollections(userId = data.userId)
+                CollectionListRouteType.RECENT -> collectionRepository.getRecentCollectionList() // 홈
             }.onSuccess { result ->
                 _uiState.update { it.copy(collectionList = UiState.Success(result)) }
             }.onFailure {

--- a/app/src/main/java/com/flint/presentation/collectionlist/CollectionListViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/CollectionListViewModel.kt
@@ -32,7 +32,7 @@ class CollectionListViewModel @Inject constructor(
     private val bookmarkRepository: BookmarkRepository,
 ) : ViewModel() {
 
-    val routeType = savedStateHandle.toRoute<Route.CollectionList>().routeType
+    val routeReceiveData = savedStateHandle.toRoute<Route.CollectionList>()
 
     private val _uiState = MutableStateFlow<CollectionListUiState>(CollectionListUiState())
     val uiState: StateFlow<CollectionListUiState> = _uiState
@@ -45,12 +45,14 @@ class CollectionListViewModel @Inject constructor(
     }
 
     private fun getCollectionList() {
+        val userId = routeReceiveData.userId
+
         viewModelScope.launch {
             _uiState.update { it.copy(collectionList = UiState.Loading) }
 
-            when (routeType) {
-                CollectionListRouteType.CREATED -> userRepository.getUserCreatedCollections(userId = null)
-                CollectionListRouteType.SAVED -> userRepository.getUserBookmarkedCollections(userId = null)
+            when (routeReceiveData.routeType) {
+                CollectionListRouteType.CREATED -> userRepository.getUserCreatedCollections(userId = userId)
+                CollectionListRouteType.SAVED -> userRepository.getUserBookmarkedCollections(userId = userId)
                 CollectionListRouteType.RECENT -> collectionRepository.getRecentCollectionList()
             }.onSuccess { result ->
                 _uiState.update { it.copy(collectionList = UiState.Success(result)) }

--- a/app/src/main/java/com/flint/presentation/collectionlist/navigation/CollectionListNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/navigation/CollectionListNavigation.kt
@@ -11,11 +11,13 @@ import com.flint.presentation.collectionlist.CollectionListRoute
 
 fun NavController.navigateToCollectionList(
     routeType: CollectionListRouteType,
+    userId: String?,
     navOptions: NavOptions? = null
 ) {
     navigate(
         Route.CollectionList(
-            routeType = routeType,
+            userId = userId,
+            routeType = routeType
         ),
         navOptions,
     )

--- a/app/src/main/java/com/flint/presentation/collectionlist/uistate/CollectionListUiState.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/uistate/CollectionListUiState.kt
@@ -4,5 +4,6 @@ import com.flint.core.common.util.UiState
 import com.flint.domain.model.collection.CollectionListModel
 
 data class CollectionListUiState(
+    val appbarTitle: String = "",
     val collectionList: UiState<CollectionListModel> = UiState.Loading
 )

--- a/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeScreen.kt
@@ -80,6 +80,7 @@ fun HomeRoute(
             val recentCollectionList = (uiState.recentCollectionListLoadState as? UiState.Success)?.data ?: CollectionListModel()
 
             HomeScreen(
+                userName = uiState.userName,
                 recommendCollectionModelList = recommendedCollectionList,
                 recentCollectionModelList = recentCollectionList,
                 savedContentModelList = bookmarkedContentList,
@@ -121,7 +122,7 @@ fun HomeRoute(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HomeScreen(
-    userName: String = "",
+    userName: String,
     recommendCollectionModelList: CollectionListModel,
     savedContentModelList: BookmarkedContentListModel,
     recentCollectionModelList: CollectionListModel,

--- a/app/src/main/java/com/flint/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/home/HomeViewModel.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
 

--- a/app/src/main/java/com/flint/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/login/LoginViewModel.kt
@@ -2,8 +2,6 @@ package com.flint.presentation.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.flint.data.local.PreferencesManager
-import com.flint.core.common.util.DataStoreKey.USER_NAME
 import com.flint.core.common.util.UiState
 import com.flint.domain.model.auth.SocialVerifyRequestModel
 import com.flint.domain.repository.AuthRepository

--- a/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
@@ -15,6 +15,7 @@ import com.flint.presentation.explore.navigation.exploreNavGraph
 import com.flint.presentation.home.navigation.homeNavGraph
 import com.flint.presentation.login.navigation.loginNavGraph
 import com.flint.presentation.onboarding.navigation.onBoardingNavGraph
+import com.flint.presentation.profile.navigation.myProfileNavGraph
 import com.flint.presentation.profile.navigation.profileNavGraph
 import com.flint.presentation.savedcontent.navigation.savedContentListNavGraph
 import com.flint.presentation.splash.navigation.splashNavGraph
@@ -88,6 +89,13 @@ fun MainNavHost(
                 paddingValues = paddingValues,
                 navigateToCollectionDetail = navigator::navigateToCollectionDetail,
                 navigateToCollectionCreate = navigator::navigateToCollectionCreate,
+            )
+
+            myProfileNavGraph(
+                paddingValues = paddingValues,
+                navigateToCollectionList = navigator::navigateToCollectionList,
+                navigateToSavedContentList = navigator::navigateToSavedContent,
+                navigateToCollectionDetail = navigator::navigateToCollectionDetail,
             )
 
             profileNavGraph(

--- a/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
@@ -19,6 +19,7 @@ import com.flint.presentation.explore.navigation.navigateToExplore
 import com.flint.presentation.home.navigation.navigateToHome
 import com.flint.presentation.login.navigation.navigateToLogin
 import com.flint.presentation.onboarding.navigation.navigateToOnboarding
+import com.flint.presentation.profile.navigation.navigateToMyProfile
 import com.flint.presentation.profile.navigation.navigateToProfile
 import com.flint.presentation.savedcontent.navigation.navigateToSavedContentList
 import kotlinx.coroutines.CoroutineScope
@@ -83,7 +84,7 @@ class MainNavigator(
         when (tab) {
             MainTab.HOME -> navController.navigateToHome(navOptions)
             MainTab.EXPLORE -> navController.navigateToExplore(navOptions)
-            MainTab.PROFILE -> navController.navigateToProfile(navOptions = navOptions)
+            MainTab.PROFILE -> navController.navigateToMyProfile(navOptions)
         }
     }
 

--- a/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
@@ -114,8 +114,8 @@ class MainNavigator(
         )
     }
 
-    fun navigateToCollectionList(routeType: CollectionListRouteType) {
-        navController.navigateToCollectionList(routeType =  routeType)
+    fun navigateToCollectionList(routeType: CollectionListRouteType, userId: String? = null) {
+        navController.navigateToCollectionList(routeType =  routeType, userId = userId)
     }
 
     fun navigateToCollectionDetail(collectionId: String) {

--- a/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.flint.core.navigation.MainTabRoute
+import com.flint.core.navigation.Route
 import com.flint.core.navigation.model.CollectionListRouteType
 import com.flint.presentation.collectioncreate.navigation.navigateToCollectionCreate
 import com.flint.presentation.collectiondetail.navigation.navigateToCollectionDetail
@@ -33,7 +33,7 @@ class MainNavigator(
     val navController: NavHostController,
     coroutineScope: CoroutineScope,
 ) {
-    val startDestination = MainTabRoute.Home
+    val startDestination = Route.Splash
 
     // NavController의 Flow를 관찰하여 현재 Destination을 StateFlow로 변환
     private val currentDestination =

--- a/app/src/main/java/com/flint/presentation/main/MainTab.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainTab.kt
@@ -22,7 +22,7 @@ enum class MainTab(
     ),
     PROFILE(
         iconResId = R.drawable.ic_my_empty,
-        route = MainTabRoute.Profile(),
+        route = MainTabRoute.Profile,
         label = "MY",
     ),
     ;

--- a/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
@@ -40,7 +40,7 @@ import com.flint.presentation.profile.uistate.ProfileUiState
 @Composable
 fun ProfileRoute(
     paddingValues: PaddingValues,
-    navigateToCollectionList: (routeType: CollectionListRouteType) -> Unit,
+    navigateToCollectionList: (routeType: CollectionListRouteType, userId: String?) -> Unit,
     navigateToSavedContentList: () -> Unit, // TODO: 스프린트에서 구현
     navigateToCollectionDetail: (collectionId: String) -> Unit,
     viewModel: ProfileViewModel = hiltViewModel(),
@@ -83,11 +83,13 @@ fun ProfileRoute(
                 onCreatedCollectionMoreClick =  {
                     navigateToCollectionList(
                         CollectionListRouteType.CREATED,
+                        state.data.userId
                     )
                 },
                 onSavedCollectionMoreClick = {
                     navigateToCollectionList(
                         CollectionListRouteType.SAVED,
+                        state.data.userId
                     )
                 },
             )

--- a/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
@@ -8,25 +8,35 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flint.core.common.util.UiState
+import com.flint.core.designsystem.component.bottomsheet.OttListBottomSheet
 import com.flint.core.designsystem.component.indicator.FlintLoadingIndicator
 import com.flint.core.designsystem.component.listView.CollectionSection
 import com.flint.core.designsystem.component.listView.SavedContentsSection
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.core.designsystem.theme.FlintTheme.colors
 import com.flint.core.navigation.model.CollectionListRouteType
+import com.flint.domain.model.ott.OttListModel
 import com.flint.presentation.profile.component.ProfileKeywordSection
 import com.flint.presentation.profile.component.ProfileTopSection
+import com.flint.presentation.profile.sideeffect.ProfileSideEffect
 import com.flint.presentation.profile.uistate.ProfileUiState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileRoute(
     paddingValues: PaddingValues,
@@ -36,9 +46,25 @@ fun ProfileRoute(
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
+
+    var showOttListBottomSheet by remember { mutableStateOf(false) }
+    var ottListModel by remember { mutableStateOf(OttListModel()) }
+    val sheetState = rememberModalBottomSheetState()
 
     LaunchedEffect(Unit) {
         viewModel.getProfile()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is ProfileSideEffect.ShowOttListBottomSheet -> {
+                    ottListModel = sideEffect.ottListModel
+                    showOttListBottomSheet = true
+                }
+            }
+        }
     }
 
     when (val state = uiState) {
@@ -51,6 +77,9 @@ fun ProfileRoute(
                 modifier = Modifier.padding(paddingValues),
                 uiState = state.data,
                 onCollectionItemClick = navigateToCollectionDetail,
+                onContentItemClick = { contentId ->
+                    viewModel.getOttListPerContent(contentId)
+                },
                 onCreatedCollectionMoreClick =  {
                     navigateToCollectionList(
                         CollectionListRouteType.CREATED,
@@ -65,6 +94,17 @@ fun ProfileRoute(
         }
 
         else -> {}
+    }
+
+    if (showOttListBottomSheet) {
+        OttListBottomSheet(
+            ottList = ottListModel,
+            onDismiss = { showOttListBottomSheet = false },
+            onMoveClick = { url ->
+                uriHandler.openUri(url)
+            },
+            sheetState = sheetState,
+        )
     }
 }
 

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -70,7 +70,7 @@ class ProfileViewModel @Inject constructor(
                     userRepository.getUserBookmarkedCollections(userId = userId).getOrThrow()
                 }
                 val savedContentListDeferred = async {
-                    contentRepository.getBookmarkedContentListByUserId(userId = userId).getOrThrow()
+                    userRepository.getUserBookmarkedContents(userId = userId).getOrThrow()
                 }
 
                 currentState.copy(

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -62,7 +62,7 @@ class ProfileViewModel @Inject constructor(
                     userRepository.getUserBookmarkedCollections(userId = userId).getOrThrow()
                 }
                 val savedContentListDeferred = async {
-                    contentRepository.getBookmarkedContentList().getOrThrow()
+                    contentRepository.getBookmarkedContentListByUserId(userId = userId).getOrThrow()
                 }
 
                 currentState.copy(

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -7,6 +7,7 @@ import androidx.navigation.toRoute
 import com.flint.core.common.util.UiState
 import com.flint.core.common.util.suspendRunCatching
 import com.flint.core.navigation.Route
+import com.flint.domain.model.user.KeywordListModel
 import com.flint.domain.repository.ContentRepository
 import com.flint.domain.repository.UserRepository
 import com.flint.presentation.profile.sideeffect.ProfileSideEffect
@@ -43,8 +44,12 @@ class ProfileViewModel @Inject constructor(
     fun getProfile() {
         viewModelScope.launch {
             suspendRunCatching {
-                val profileDeferred = async { userRepository.getUserProfile(userId = userId).getOrThrow() }
-                val keywordsDeferred = async { userRepository.getUserKeywords(userId = userId).getOrThrow() }
+                val profileDeferred = async {
+                    userRepository.getUserProfile(userId = userId).getOrThrow()
+                }
+                val keywordsDeferred = async {
+                    userRepository.getUserKeywords(userId = userId).getOrDefault(KeywordListModel())
+                }
 
                 ProfileUiState(
                     userId = userId,

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -12,11 +12,15 @@ import com.flint.domain.repository.UserRepository
 import com.flint.presentation.profile.uistate.ProfileUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.flint.presentation.profile.sideeffect.ProfileSideEffect
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -32,6 +36,9 @@ class ProfileViewModel @Inject constructor(
         UiState.Empty
     )
     val uiState: StateFlow<UiState<ProfileUiState>> = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<ProfileSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
 
     fun getProfile() {
         viewModelScope.launch {
@@ -74,5 +81,15 @@ class ProfileViewModel @Inject constructor(
                 _uiState.update { UiState.Success(updatedState) }
             }
         }
+    }
+
+    fun getOttListPerContent(contentId: String) = viewModelScope.launch {
+        contentRepository.getOttListPerContent(contentId)
+            .onSuccess {
+                _sideEffect.emit(ProfileSideEffect.ShowOttListBottomSheet(it))
+            }
+            .onFailure {
+                Timber.e(it)
+            }
     }
 }

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -1,9 +1,12 @@
 package com.flint.presentation.profile
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.flint.core.common.util.UiState
 import com.flint.core.common.util.suspendRunCatching
+import com.flint.core.navigation.MainTabRoute
 import com.flint.domain.repository.ContentRepository
 import com.flint.domain.repository.UserRepository
 import com.flint.presentation.profile.uistate.ProfileUiState
@@ -18,9 +21,13 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val userRepository: UserRepository,
     private val contentRepository: ContentRepository
 ) : ViewModel() {
+
+    val userId = savedStateHandle.toRoute<MainTabRoute.Profile>().userId
+
     private val _uiState = MutableStateFlow<UiState<ProfileUiState>>(
         UiState.Empty
     )
@@ -29,8 +36,8 @@ class ProfileViewModel @Inject constructor(
     fun getProfile() {
         viewModelScope.launch {
             suspendRunCatching {
-                val profileDeferred = async { userRepository.getUserProfile(userId = null).getOrThrow() }
-                val keywordsDeferred = async { userRepository.getUserKeywords(userId = null).getOrThrow() }
+                val profileDeferred = async { userRepository.getUserProfile(userId = userId).getOrThrow() }
+                val keywordsDeferred = async { userRepository.getUserKeywords(userId = userId).getOrThrow() }
 
                 ProfileUiState(
                     profile = profileDeferred.await(),
@@ -49,10 +56,10 @@ class ProfileViewModel @Inject constructor(
 
             suspendRunCatching {
                 val createdCollectionsDeferred = async {
-                    userRepository.getUserCreatedCollections(userId = null).getOrThrow()
+                    userRepository.getUserCreatedCollections(userId = userId).getOrThrow()
                 }
                 val bookmarkedCollectionsDeferred = async {
-                    userRepository.getUserBookmarkedCollections(userId = null).getOrThrow()
+                    userRepository.getUserBookmarkedCollections(userId = userId).getOrThrow()
                 }
                 val savedContentListDeferred = async {
                     contentRepository.getBookmarkedContentList().getOrThrow()

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -47,6 +47,7 @@ class ProfileViewModel @Inject constructor(
                 val keywordsDeferred = async { userRepository.getUserKeywords(userId = userId).getOrThrow() }
 
                 ProfileUiState(
+                    userId = userId,
                     profile = profileDeferred.await(),
                     keywords = keywordsDeferred.await()
                 )

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -6,9 +6,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.flint.core.common.util.UiState
 import com.flint.core.common.util.suspendRunCatching
-import com.flint.core.navigation.MainTabRoute
+import com.flint.core.navigation.Route
 import com.flint.domain.repository.ContentRepository
 import com.flint.domain.repository.UserRepository
+import com.flint.presentation.profile.sideeffect.ProfileSideEffect
 import com.flint.presentation.profile.uistate.ProfileUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -19,7 +20,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import com.flint.presentation.profile.sideeffect.ProfileSideEffect
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -30,7 +30,7 @@ class ProfileViewModel @Inject constructor(
     private val contentRepository: ContentRepository
 ) : ViewModel() {
 
-    val userId = savedStateHandle.toRoute<MainTabRoute.Profile>().userId
+    val userId = savedStateHandle.toRoute<Route.Profile>().userId
 
     private val _uiState = MutableStateFlow<UiState<ProfileUiState>>(
         UiState.Empty

--- a/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
@@ -6,14 +6,37 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.flint.core.navigation.MainTabRoute
+import com.flint.core.navigation.Route
 import com.flint.core.navigation.model.CollectionListRouteType
 import com.flint.presentation.profile.ProfileRoute
+
+fun NavController.navigateToMyProfile(
+    navOptions: NavOptions? = null
+) {
+    navigate((MainTabRoute.Profile), navOptions)
+}
 
 fun NavController.navigateToProfile(
     userId: String? = null,
     navOptions: NavOptions? = null,
 ) {
-    navigate(MainTabRoute.Profile(userId = userId), navOptions)
+    navigate(Route.Profile(userId = userId), navOptions)
+}
+
+fun NavGraphBuilder.myProfileNavGraph(
+    paddingValues: PaddingValues,
+    navigateToCollectionList: (routeType: CollectionListRouteType) -> Unit,
+    navigateToSavedContentList: () -> Unit,
+    navigateToCollectionDetail: (collectionId: String) -> Unit,
+) {
+    composable<MainTabRoute.Profile> {
+        ProfileRoute(
+            paddingValues = paddingValues,
+            navigateToCollectionList = navigateToCollectionList,
+            navigateToSavedContentList = navigateToSavedContentList,
+            navigateToCollectionDetail = navigateToCollectionDetail,
+        )
+    }
 }
 
 fun NavGraphBuilder.profileNavGraph(
@@ -22,7 +45,7 @@ fun NavGraphBuilder.profileNavGraph(
     navigateToSavedContentList: () -> Unit,
     navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {
-    composable<MainTabRoute.Profile> {
+    composable<Route.Profile> {
         ProfileRoute(
             paddingValues = paddingValues,
             navigateToCollectionList = navigateToCollectionList,

--- a/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
@@ -25,7 +25,7 @@ fun NavController.navigateToProfile(
 
 fun NavGraphBuilder.myProfileNavGraph(
     paddingValues: PaddingValues,
-    navigateToCollectionList: (routeType: CollectionListRouteType) -> Unit,
+    navigateToCollectionList: (routeType: CollectionListRouteType, userId: String?) -> Unit,
     navigateToSavedContentList: () -> Unit,
     navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {
@@ -41,7 +41,7 @@ fun NavGraphBuilder.myProfileNavGraph(
 
 fun NavGraphBuilder.profileNavGraph(
     paddingValues: PaddingValues,
-    navigateToCollectionList: (routeType: CollectionListRouteType) -> Unit,
+    navigateToCollectionList: (routeType: CollectionListRouteType, userId: String?) -> Unit,
     navigateToSavedContentList: () -> Unit,
     navigateToCollectionDetail: (collectionId: String) -> Unit,
 ) {

--- a/app/src/main/java/com/flint/presentation/profile/sideeffect/ProfileSideEffect.kt
+++ b/app/src/main/java/com/flint/presentation/profile/sideeffect/ProfileSideEffect.kt
@@ -1,0 +1,7 @@
+package com.flint.presentation.profile.sideeffect
+
+import com.flint.domain.model.ott.OttListModel
+
+interface ProfileSideEffect {
+    data class ShowOttListBottomSheet(val ottListModel: OttListModel) : ProfileSideEffect
+}

--- a/app/src/main/java/com/flint/presentation/profile/uistate/ProfileUiState.kt
+++ b/app/src/main/java/com/flint/presentation/profile/uistate/ProfileUiState.kt
@@ -8,6 +8,7 @@ import com.flint.domain.model.user.UserProfileResponseModel
 
 @Immutable
 data class ProfileUiState(
+    val userId: String? = null,
     val keywords: KeywordListModel,
     val profile: UserProfileResponseModel,
     val savedContents: BookmarkedContentListModel = BookmarkedContentListModel(),

--- a/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
@@ -2,21 +2,31 @@ package com.flint.presentation.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.flint.core.common.util.DataStoreKey.ACCESS_TOKEN
+import com.flint.core.common.util.DataStoreKey.USER_ID
+import com.flint.core.common.util.DataStoreKey.USER_NAME
 import com.flint.data.local.PreferencesManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SplashViewModel
-    @Inject
-    constructor(
+class SplashViewModel @Inject constructor(
         private val preferencesManager: PreferencesManager,
-    ) : ViewModel() {
+) : ViewModel() {
     val prefData = preferencesManager.getString("sampleKey")
 
-        fun sampleSaveData() =
-            viewModelScope.launch {
-                preferencesManager.saveString("sampleKey", "sampleValue")
-            }
+    init {
+        saveTempUserData()
     }
+
+    fun sampleSaveData() = viewModelScope.launch {
+        preferencesManager.saveString("sampleKey", "sampleValue")
+    }
+
+    fun saveTempUserData() = viewModelScope.launch {
+        preferencesManager.saveString(ACCESS_TOKEN, "eyJhbGciOiJIUzUxMiJ9.eyJ1c2VySWQiOjgwMDAyMTcxMTM1NzExODE5MSwicm9sZSI6IkZMSU5HIiwidHlwZSI6IkFDQ0VTUyIsImlhdCI6MTc2ODgzODU0MCwiZXhwIjoxNzcwMDQ4MTQwfQ.A2XYyu24IoGAXNSQHJ1S-iudWmg8II2_ivI4EdyyWw9KS9oJlxHKOAhcKrsLpLkc9kllZyxwaTJO1t4vI7oZlg")
+        preferencesManager.saveString(USER_ID, "800021711357118191")
+        preferencesManager.saveString(USER_NAME, "hojoo")
+    }
+}

--- a/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
@@ -2,13 +2,9 @@ package com.flint.presentation.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.flint.core.common.util.DataStoreKey.USER_ID
-import com.flint.core.common.util.DataStoreKey.USER_NAME
 import com.flint.data.local.PreferencesManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -17,18 +13,10 @@ class SplashViewModel
     constructor(
         private val preferencesManager: PreferencesManager,
     ) : ViewModel() {
-        init {
-            sampleSaveData()
-        }
-        val prefData = preferencesManager.getString(USER_ID)
+    val prefData = preferencesManager.getString("sampleKey")
 
         fun sampleSaveData() =
             viewModelScope.launch {
-//                preferencesManager.saveString(USER_ID, "801159854933808613")
-//                preferencesManager.saveString(USER_NAME, "코코아")
-
                 preferencesManager.saveString("sampleKey", "sampleValue")
-
-                Timber.d("prefData: ${prefData.first()}")
             }
     }

--- a/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
@@ -2,9 +2,13 @@ package com.flint.presentation.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.flint.core.common.util.DataStoreKey.USER_ID
+import com.flint.core.common.util.DataStoreKey.USER_NAME
 import com.flint.data.local.PreferencesManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -13,10 +17,18 @@ class SplashViewModel
     constructor(
         private val preferencesManager: PreferencesManager,
     ) : ViewModel() {
-        val prefData = preferencesManager.getString("sampleKey")
+        init {
+            sampleSaveData()
+        }
+        val prefData = preferencesManager.getString(USER_ID)
 
         fun sampleSaveData() =
             viewModelScope.launch {
+//                preferencesManager.saveString(USER_ID, "801159854933808613")
+//                preferencesManager.saveString(USER_NAME, "코코아")
+
                 preferencesManager.saveString("sampleKey", "sampleValue")
+
+                Timber.d("prefData: ${prefData.first()}")
             }
     }

--- a/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
@@ -14,14 +14,8 @@ import javax.inject.Inject
 class SplashViewModel @Inject constructor(
         private val preferencesManager: PreferencesManager,
 ) : ViewModel() {
-    val prefData = preferencesManager.getString("sampleKey")
-
     init {
-        saveTempUserData()
-    }
-
-    fun sampleSaveData() = viewModelScope.launch {
-        preferencesManager.saveString("sampleKey", "sampleValue")
+//        saveTempUserData()
     }
 
     fun saveTempUserData() = viewModelScope.launch {


### PR DESCRIPTION
## 📮 관련 이슈
- closed #157 

## 📌 작업 내용
- userId 바탕 내 프로필/타인 프로필 화면이동 및 API 호출 구분
- 저장한 작품 OTT 바텀시트 추가
- 토큰 저장 로직 개선

## 📸 스크린샷
| 프로필 이동 | 북마크 낙관적 UI |
|:--:|:--:|
| <video width="360" src="https://github.com/user-attachments/assets/84716324-d17b-4cf0-a44a-4b5b4037896e"/> | <video width="360" src="https://github.com/user-attachments/assets/cdbf22b6-dc11-4e3b-adc3-8354175e411a"/>


## 🫛 To. 리뷰어
- 내 프로필은 비공개 컬렉션도 다 보여줘야 해서.. API를 다른 걸 써야하네요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 프로필 화면에서 콘텐츠 클릭 시 OTT 리스트 하단 팝업 표시 추가
  * 사용자별 북마크된 콘텐츠 조회 기능 추가
  * 컬렉션 목록에서 다른 사용자의 생성/북마크 컬렉션 조회 지원

* **개선 사항**
  * 인증 토큰·유저 ID 저장 흐름 개선
  * 컬렉션 북마크 토글에 낙관적 UI와 디바운스(롤백 지원) 도입
  * 내비게이션 및 화면 간 파라미터 전달 개선 (userId 포함)

* **기타**
  * 화면 상태(앱바 제목 등) 및 프로필 상태 노출 확장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->