### PR TITLE
[Feat] 탐색 화면 셀프 QA

### DIFF
--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -38,6 +38,7 @@ interface Route {
     @Serializable
     data class CollectionDetail(
         val collectionId: String,
+        val targetImageUrl: String? = null,
     ) : Route
 
     @Serializable

--- a/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
@@ -237,7 +237,6 @@ fun CollectionDetailScreen(
         val scrollState: ScrollState = rememberScrollState()
         var thumbnailHeight: Int by remember { mutableIntStateOf(0) }
         val contentPositions: MutableMap<String, Int> = remember { mutableMapOf() }
-        var hasScrolledToTarget: Boolean by remember { mutableStateOf(false) }
 
         val scrollProgress: Float =
             if (scrollState.maxValue > 0) {
@@ -248,14 +247,11 @@ fun CollectionDetailScreen(
 
         val isProgressBarSticky: Boolean = scrollState.value >= thumbnailHeight
 
-        LaunchedEffect(targetImageUrl, contentPositions.size) {
-            if (!hasScrolledToTarget && targetImageUrl != null && contentPositions.isNotEmpty()) {
-                val targetPosition = contentPositions[targetImageUrl]
-                if (targetPosition != null) {
-                    scrollState.animateScrollTo(targetPosition)
-                    hasScrolledToTarget = true
-                }
-            }
+        LaunchedEffect(Unit) {
+            if (targetImageUrl == null) return@LaunchedEffect
+            val targetPosition: Int = contentPositions[targetImageUrl] ?: return@LaunchedEffect
+
+            scrollState.animateScrollTo(targetPosition)
         }
 
         if (showPeopleBottomSheet) {

--- a/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
@@ -67,6 +67,7 @@ import com.flint.core.designsystem.component.toast.ShowSaveToast
 import com.flint.core.designsystem.component.toast.ShowToast
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.core.navigation.model.CollectionListRouteType
 import com.flint.domain.model.bookmark.CollectionBookmarkUsersModel
 import com.flint.domain.model.collection.CollectionDetailModelNew
 import com.flint.domain.model.content.ContentModel
@@ -75,17 +76,16 @@ import com.flint.domain.type.OttType
 import com.flint.domain.type.UserRoleType
 import com.flint.presentation.collectiondetail.sideeffect.CollectionDetailSideEffect
 import com.flint.presentation.collectiondetail.uistate.CollectionDetailUiState
-import com.flint.core.navigation.model.CollectionListRouteType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun CollectionDetailRoute(
     paddingValues: PaddingValues,
-    targetImageUrl: String? = null,
     navigateToCollectionList: (CollectionListRouteType) -> Unit,
     navigateToProfile: (authorId: String) -> Unit,
     navigateUp: () -> Unit,
+    targetImageUrl: String? = null,
     viewModel: CollectionDetailViewModel = hiltViewModel(),
 ) {
     val uiState: UiState<CollectionDetailUiState> by viewModel.uiState.collectAsStateWithLifecycle()
@@ -212,7 +212,6 @@ fun CollectionDetailRoute(
 @Composable
 fun CollectionDetailScreen(
     paddingValues: PaddingValues,
-    targetImageUrl: String? = null,
     title: String,
     isMine: Boolean,
     isBookmarked: Boolean,
@@ -229,6 +228,7 @@ fun CollectionDetailScreen(
     onSpoilClick: (String) -> Unit,
     onAuthorNicknameClick: () -> Unit,
     onAuthorClick: (authorId: String) -> Unit,
+    targetImageUrl: String? = null,
 ) {
     CompositionLocalProvider(
         LocalOverscrollFactory provides null,
@@ -329,7 +329,8 @@ fun CollectionDetailScreen(
                             onBookmarkIconClick = onBookmarkIconClick,
                             onSpoilClick = onSpoilClick,
                             modifier = Modifier.onGloballyPositioned { coordinates ->
-                                contentPositions[content.imageUrl] = coordinates.positionInParent().y.toInt()
+                                contentPositions[content.imageUrl] =
+                                    coordinates.positionInParent().y.toInt()
                             },
                         )
                     }

--- a/app/src/main/java/com/flint/presentation/collectiondetail/navigation/CollectionDetailNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/navigation/CollectionDetailNavigation.kt
@@ -5,15 +5,23 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.flint.core.navigation.Route
 import com.flint.core.navigation.model.CollectionListRouteType
 import com.flint.presentation.collectiondetail.CollectionDetailRoute
 
 fun NavController.navigateToCollectionDetail(
     collectionId: String,
+    targetImageUrl: String? = null,
     navOptions: NavOptions? = null,
 ) {
-    navigate(Route.CollectionDetail(collectionId = collectionId), navOptions)
+    navigate(
+        Route.CollectionDetail(
+            collectionId = collectionId,
+            targetImageUrl = targetImageUrl,
+        ),
+        navOptions,
+    )
 }
 
 fun NavGraphBuilder.collectionDetailNavGraph(
@@ -22,12 +30,14 @@ fun NavGraphBuilder.collectionDetailNavGraph(
     navigateUp: () -> Unit,
     navigateToProfile: (userId: String) -> Unit,
 ) {
-    composable<Route.CollectionDetail> {
+    composable<Route.CollectionDetail> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.CollectionDetail>()
         CollectionDetailRoute(
             paddingValues = paddingValues,
+            targetImageUrl = route.targetImageUrl,
             navigateToCollectionList = navigateToCollectionList,
             navigateUp = navigateUp,
-            navigateToProfile = navigateToProfile
+            navigateToProfile = navigateToProfile,
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -47,7 +47,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun ExploreRoute(
     paddingValues: PaddingValues,
-    navigateToCollectionDetail: (collectionId: String) -> Unit,
+    navigateToCollectionDetail: (collectionId: String, imageUrl: String) -> Unit,
     navigateToCollectionCreate: () -> Unit,
     viewModel: ExploreViewModel = hiltViewModel(),
 ) {
@@ -76,7 +76,7 @@ fun ExploreRoute(
 @Composable
 private fun ExploreScreen(
     collections: ImmutableList<CollectionsModel.Collection>,
-    onWatchCollectionButtonClick: (collectionId: String) -> Unit,
+    onWatchCollectionButtonClick: (collectionId: String, imageUrl: String) -> Unit,
     onMakeCollectionButtonClick: () -> Unit,
     onLoadNextPage: () -> Unit,
     modifier: Modifier = Modifier,
@@ -117,7 +117,7 @@ private fun ExploreScreen(
                     id = collection.collectionId,
                     title = collection.title,
                     description = collection.description,
-                    onButtonClick = onWatchCollectionButtonClick,
+                    onButtonClick = { onWatchCollectionButtonClick(it, collection.imageUrl) },
                 )
             } else {
                 ExploreEndPage(
@@ -295,7 +295,7 @@ private fun ExploreScreenPreview() {
                             """.trimIndent(),
                     )
                 }.toImmutableList(),
-            onWatchCollectionButtonClick = {},
+            onWatchCollectionButtonClick = { _, _ -> },
             onMakeCollectionButtonClick = {},
             onLoadNextPage = {},
             modifier =

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -162,6 +163,8 @@ private fun ExplorePageItem(
                 text = title,
                 color = FlintTheme.colors.white,
                 style = FlintTheme.typography.display2M28,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
 
             Spacer(Modifier.height(12.dp))
@@ -195,7 +198,7 @@ private fun ExplorePageItemPreview() {
         ExplorePageItem(
             imageUrl = "https://buly.kr/G3Edbfu",
             id = "",
-            title = "너의 모든 것",
+            title = "너의 모든 것".repeat(10),
             description =
                 """
                 뉴욕의 서점 매니저이자 반듯한 독서가, 조. 

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -173,6 +173,8 @@ private fun ExplorePageItem(
                 text = description,
                 color = FlintTheme.colors.white,
                 style = FlintTheme.typography.body1R16,
+                maxLines = 8,
+                overflow = TextOverflow.Ellipsis
             )
 
             Spacer(Modifier.height(28.dp))
@@ -205,7 +207,8 @@ private fun ExplorePageItemPreview() {
                 그가 대학원생 벡을 만나 한눈에 반한다. 
                 하지만 훈훈했던 그의 첫인상은 잠시일 뿐, 
                 감추어진 조의 뒤틀린 이면이 드러난다.
-                """.trimIndent(),
+                
+                """.trimIndent().repeat(10),
             onButtonClick = {},
         )
     }

--- a/app/src/main/java/com/flint/presentation/explore/navigation/ExploreNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/explore/navigation/ExploreNavigation.kt
@@ -14,7 +14,7 @@ fun NavController.navigateToExplore(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.exploreNavGraph(
     paddingValues: PaddingValues,
-    navigateToCollectionDetail: (collectionId: String) -> Unit,
+    navigateToCollectionDetail: (collectionId: String, imageUrl: String) -> Unit,
     navigateToCollectionCreate: () -> Unit,
 ) {
     composable<MainTabRoute.Explore> {

--- a/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavigator.kt
@@ -118,8 +118,11 @@ class MainNavigator(
         navController.navigateToCollectionList(routeType =  routeType, userId = userId)
     }
 
-    fun navigateToCollectionDetail(collectionId: String) {
-        navController.navigateToCollectionDetail(collectionId = collectionId)
+    fun navigateToCollectionDetail(collectionId: String, targetImageUrl: String? = null) {
+        navController.navigateToCollectionDetail(
+            collectionId = collectionId,
+            targetImageUrl = targetImageUrl,
+        )
     }
 
     fun navigateToCollectionCreate() {


### PR DESCRIPTION
## 📮 관련 이슈
- closed #167 

## 📌 작업 내용
- [feat: 작품 제목은 글자 수 기준이 아닌, 텍스트 박스 width 기준으로 최대 2줄까지 표시한다](https://github.com/imflint/Flint-Android/commit/18127943ed411cc380f663a949f61f16fa0ea5b2)

- [feat: 작품 소개는 8줄까지만 노출된다. 텍스트가 width 기준으로 줄바꿈될 경우, 해당 줄에 딱 걸리는 음절 단위에서…](https://github.com/imflint/Flint-Android/commit/694e0ac4e60063a038ddc931cbe33f4b6d8ddae6) 
- 컬렉션 상세 페이지 진입 시 자동 스크롤 처리를 통해 해당 작품 섹션의 위치로 바로 노출한다

## 📸 스크린샷
| 자동 스크롤 |
|:--:|
| <video width="360" src="https://github.com/user-attachments/assets/90bbc025-fece-45a5-911e-f9782e2ebad6" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 컬렉션 상세 페이지에서 특정 이미지로 자동 스크롤하는 기능 추가
  * 컬렉션 상세 이동 시 특정 이미지 정보 전달 가능

* **개선사항**
  * 탐색(Explore) 항목의 제목 및 설명에 텍스트 오버플로우 처리 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->