### PR TITLE
[Feat] 온보딩 UI 개편

### DIFF
--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -59,7 +59,7 @@ import com.flint.presentation.onboarding.component.StepProgressBar
 @Composable
 fun OnboardingContentRoute(
     paddingValues: PaddingValues,
-    navigateToOnboardingOtt: () -> Unit,
+    navigateToOnboardingDone: () -> Unit,
     navigateUp: () -> Unit,
     viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
@@ -74,7 +74,7 @@ fun OnboardingContentRoute(
         nickname = profileUiState.nickname,
         contentUiState = contentUiState,
         onBackClick = navigateUp,
-        onNextClick = navigateToOnboardingOtt,
+        onNextClick = navigateToOnboardingDone,
         onSearchKeywordChanged = viewModel::updateSearchKeyword,
         onSearchAction = viewModel::searchContents,
         onClearAction = viewModel::loadInitialContents,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -51,6 +51,7 @@ import com.flint.core.designsystem.component.view.FlintSearchEmptyView
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.search.SearchContentItemModel
 import com.flint.domain.model.search.SearchContentListModel
+import com.flint.presentation.onboarding.component.FlintGenreChip
 import com.flint.presentation.onboarding.component.OnboardingContentItem
 import com.flint.presentation.onboarding.component.StepProgressBar
 
@@ -78,6 +79,7 @@ fun OnboardingContentRoute(
         onClearAction = viewModel::loadInitialContents,
         onContentClick = viewModel::toggleContentSelection,
         onRemoveContent = viewModel::toggleContentSelection,
+        onGenreClick = viewModel::selectGenre,
         modifier = Modifier.padding(paddingValues),
     )
 }
@@ -93,6 +95,7 @@ fun OnboardingContentScreen(
     onClearAction: () -> Unit,
     onContentClick: (SearchContentItemModel) -> Unit,
     onRemoveContent: (SearchContentItemModel) -> Unit,
+    onGenreClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -148,13 +151,22 @@ fun OnboardingContentScreen(
                             .background(FlintTheme.colors.background)
                             .padding(bottom = 16.dp)
                     ) {
-                        Text(
-                            text = contentUiState.currentStepQuestion,
-                            color = FlintTheme.colors.gray300,
-                            style = FlintTheme.typography.body2R14,
-                        )
-
-                        Spacer(modifier = Modifier.height(24.dp))
+                        // 장르 칩 가로 스크롤
+                        LazyRow(
+                            modifier = Modifier.height(48.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            contentPadding = PaddingValues(end = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            items(OnboardingContentUiState.GENRES) { genre ->
+                                val isSelected = genre in contentUiState.selectedGenres
+                                FlintGenreChip(
+                                    text = genre,
+                                    isSelected = isSelected,
+                                    onClick = { onGenreClick(genre) },
+                                )
+                            }
+                        }
 
                         FlintSearchTextField(
                             placeholder = "작품 이름",
@@ -305,6 +317,7 @@ private fun OnboardingContentScreenListPreview() {
             onClearAction = {},
             onContentClick = {},
             onRemoveContent = {},
+            onGenreClick = {},
         )
     }
 }
@@ -329,6 +342,39 @@ private fun OnboardingContentScreenEmptyPreview() {
             onClearAction = {},
             onContentClick = {},
             onRemoveContent = {},
+            onGenreClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "장르 칩 인터랙티브")
+@Composable
+private fun OnboardingContentScreenGenreInteractivePreview() {
+    var selectedGenres by remember { mutableStateOf(setOf<String>()) }
+
+    FlintTheme {
+        OnboardingContentScreen(
+            nickname = "안비",
+            contentUiState = OnboardingContentUiState(
+                searchResults = UiState.Success(SearchContentListModel.FakeList),
+                selectedGenres = selectedGenres.toList().let {
+                    kotlinx.collections.immutable.persistentListOf(*it.toTypedArray())
+                },
+            ),
+            onBackClick = {},
+            onNextClick = {},
+            onSearchKeywordChanged = {},
+            onSearchAction = {},
+            onClearAction = {},
+            onContentClick = {},
+            onRemoveContent = {},
+            onGenreClick = { genre ->
+                selectedGenres = if (genre in selectedGenres) {
+                    selectedGenres - genre
+                } else {
+                    selectedGenres + genre
+                }
+            },
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
@@ -153,9 +154,21 @@ fun OnboardingContentScreen(
                     ) {
                         // 장르 칩 가로 스크롤
                         LazyRow(
-                            modifier = Modifier.height(48.dp),
+                            modifier = Modifier
+                                .height(48.dp)
+                                .layout { measurable, constraints ->
+                                    val sidePadding = 16.dp.roundToPx()
+                                    val placeable = measurable.measure(
+                                        constraints.copy(
+                                            maxWidth = constraints.maxWidth + sidePadding * 2,
+                                        ),
+                                    )
+                                    layout(constraints.maxWidth, placeable.height) {
+                                        placeable.place(-sidePadding, 0)
+                                    }
+                                },
+                            contentPadding = PaddingValues(start = 16.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            contentPadding = PaddingValues(end = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             items(OnboardingContentUiState.GENRES) { genre ->
@@ -195,6 +208,18 @@ fun OnboardingContentScreen(
                             Spacer(modifier = Modifier.height(16.dp))
                             LazyRow(
                                 state = lazyListState,
+                                modifier = Modifier.layout { measurable, constraints ->
+                                    val sidePadding = 16.dp.roundToPx()
+                                    val placeable = measurable.measure(
+                                        constraints.copy(
+                                            maxWidth = constraints.maxWidth + sidePadding * 2,
+                                        ),
+                                    )
+                                    layout(constraints.maxWidth, placeable.height) {
+                                        placeable.place(-sidePadding, 0)
+                                    }
+                                },
+                                contentPadding = PaddingValues(start = 16.dp),
                                 horizontalArrangement = Arrangement.spacedBy(0.dp),
                             ) {
                                 items(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -48,23 +48,15 @@ data class OnboardingContentUiState(
     val searchResults: UiState<ImmutableList<SearchContentItemModel>> = UiState.Empty,
     val selectedContents: ImmutableList<SearchContentItemModel> = persistentListOf(),
     val isSearching: Boolean = false,
+    val selectedGenres: ImmutableList<String> = persistentListOf(),
 ) {
     companion object {
         const val REQUIRED_SELECTION_COUNT = 7
 
-        private val STEP_QUESTIONS = listOf(
-            "이번 달 가장 재미있었던 작품은?",
-            "여러번 정주행 했던 작품은 무엇인가요?",
-            "좋아하는 인물이 등장하는 작품은 무엇인가요?",
-            "요즘 밥 먹으면서 자주 보는 작품은 무엇인가요?",
-            "\"이건 꼭 봐\"라고 말했던 작품은 무엇인가요?",
-            "계절마다 생각나는 작품은 무엇인가요?",
-            "어렸을 적 즐겨봤던 추억의 작품은 무엇인가요?"
+        val GENRES = listOf(
+            "액션", "로맨스", "SF", "드라마", "코미디", "호러"
         )
     }
-
-    val currentStepQuestion: String
-        get() = STEP_QUESTIONS.getOrElse(selectedContents.size) { STEP_QUESTIONS.first() }
 
     val canProceed: Boolean
         get() = selectedContents.size == REQUIRED_SELECTION_COUNT

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -121,8 +121,6 @@ class OnboardingViewModel
             }
             currentState.copy(selectedGenres = newSelectedGenres)
         }
-        val keyword = _contentUiState.value.searchKeyword
-        getSearchContentList(keyword.ifEmpty { null })
     }
 
     private fun getSearchContentList(keyword: String?) {

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -111,6 +111,20 @@ class OnboardingViewModel
         getSearchContentList(keyword.ifEmpty { null })
     }
 
+    fun selectGenre(genre: String) {
+        _contentUiState.update { currentState ->
+            val current = currentState.selectedGenres
+            val newSelectedGenres = if (genre in current) {
+                current.filterNot { it == genre }.toImmutableList()
+            } else {
+                (current + genre).toImmutableList()
+            }
+            currentState.copy(selectedGenres = newSelectedGenres)
+        }
+        val keyword = _contentUiState.value.searchKeyword
+        getSearchContentList(keyword.ifEmpty { null })
+    }
+
     private fun getSearchContentList(keyword: String?) {
         viewModelScope.launch {
             _contentUiState.update { it.copy(searchResults = UiState.Loading) }

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -59,7 +59,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
             OnboardingContentRoute(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
-                navigateToOnboardingOtt = navController::navigateToOnboardingOtt,
+                navigateToOnboardingDone = navController::navigateToOnboardingDone,
                 viewModel = sharedViewModel,
                 )
         }


### PR DESCRIPTION
## 📮 관련 이슈
- closed #이슈번호

## 📌 작업 내용
- 온보딩 화면에 장르칩을 추가했습니다.
- 장르칩과, 선택된 영화 리스트 디쌤들과 논의 후 처음엔 왼쪽 패딩 값 적용, 좌우 스크롤 시 화면에 꽉찬뒤 잘리게 수정했습니다.
- 화면설계서 바탕으로 온보딩 화면에서 Ott화면이 삭제되면서 바로  OnboardingDone화면으로 이동하게 수정했습니다.

## 📸 스크린샷
| 스크린샷 |
|:--:|
| <video width="360" src="https://github.com/user-attachments/assets/f9131e40-d8d6-419a-8ba1-b5fe7206ed4a" /> |

## 😅 미구현
- [ ] 

## 🫛 To. 리뷰어
- 피그마 보고 장르칩이랑 검색창 부분 맞췄는데, 뭔가 더 가깝게 느껴지는 느낌이 드네요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 온보딩 화면에 가로 스크롤 가능한 장르 칩 UI 추가 — 원하는 장르를 탭해 선택 가능.
  * 선택 상태는 시각적으로 표시되며 탭으로 토글됩니다.
  * 장르 선택은 검색 결과와 온보딩 진행에 반영되어, 선택에 따라 실시간으로 내용이 업데이트되고 온보딩 완료로 진행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->