### PR TITLE
[Feat] 회원가입 api 수정

### DIFF
--- a/app/src/main/java/com/flint/data/api/SearchApi.kt
+++ b/app/src/main/java/com/flint/data/api/SearchApi.kt
@@ -14,8 +14,11 @@ interface SearchApi {
         @Query("size") size: Int
     ) : BaseResponse<SearchBookmarkedContentsResponseDto>
 
-    @GET("/api/v1/search/contents")
+    @GET("/api/v1/contents/search")
     suspend fun getSearchContentList(
-        @Query("keyword") keyword: String?
+        @Query("keyword") keyword: String? = null,
+        @Query("genre") genre: String? = null,
+        @Query("cursor") cursor: Int = 1,
+        @Query("size") size: Int = 20,
     ): BaseResponse<SearchContentsResponseDto>
 }

--- a/app/src/main/java/com/flint/data/api/TermsApi.kt
+++ b/app/src/main/java/com/flint/data/api/TermsApi.kt
@@ -1,0 +1,20 @@
+package com.flint.data.api
+
+import com.flint.data.dto.base.BaseResponse
+import com.flint.data.dto.terms.response.TermResponseDto
+import com.flint.data.dto.terms.response.TermsListResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface TermsApi {
+    @GET("/api/v1/terms")
+    suspend fun getTermsList(
+        @Query("type") type: String? = null,
+    ): BaseResponse<TermsListResponseDto>
+
+    @GET("/api/v1/terms/{termsId}")
+    suspend fun getTermsDetail(
+        @Path("termsId") termsId: Long,
+    ): BaseResponse<TermResponseDto>
+}

--- a/app/src/main/java/com/flint/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/flint/data/di/ServiceModule.kt
@@ -7,6 +7,7 @@ import com.flint.data.api.ContentApi
 import com.flint.data.api.HomeApi
 import com.flint.data.api.SearchApi
 import com.flint.data.api.StorageApi
+import com.flint.data.api.TermsApi
 import com.flint.data.api.UserApi
 import dagger.Module
 import dagger.Provides
@@ -49,4 +50,8 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideStorageApi(retrofit: Retrofit): StorageApi = retrofit.create(StorageApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideTermsApi(retrofit: Retrofit): TermsApi = retrofit.create(TermsApi::class.java)
 }

--- a/app/src/main/java/com/flint/data/di/interceptor/NetworkErrorInterceptor.kt
+++ b/app/src/main/java/com/flint/data/di/interceptor/NetworkErrorInterceptor.kt
@@ -39,18 +39,24 @@ class NetworkErrorInterceptor @Inject constructor(
 
             response
         } catch (e: UnknownHostException) {
-            scope.launch {
-                networkErrorManager.emitError(NetworkError.NoInternet)
+            if (!chain.call().isCanceled()) {
+                scope.launch {
+                    networkErrorManager.emitError(NetworkError.NoInternet)
+                }
             }
             throw e
         } catch (e: SocketTimeoutException) {
-            scope.launch {
-                networkErrorManager.emitError(NetworkError.Timeout)
+            if (!chain.call().isCanceled()) {
+                scope.launch {
+                    networkErrorManager.emitError(NetworkError.Timeout)
+                }
             }
             throw e
         } catch (e: IOException) {
-            scope.launch {
-                networkErrorManager.emitError(NetworkError.UnknownError(e.message))
+            if (!chain.call().isCanceled()) {
+                scope.launch {
+                    networkErrorManager.emitError(NetworkError.UnknownError(e.message))
+                }
             }
             throw e
         }

--- a/app/src/main/java/com/flint/data/dto/auth/request/SignupRequestDto.kt
+++ b/app/src/main/java/com/flint/data/dto/auth/request/SignupRequestDto.kt
@@ -11,6 +11,6 @@ data class SignupRequestDto(
     val nickname: String,
     @SerialName("favoriteContentIds")
     val favoriteContentIds: List<Long>,
-    @SerialName("subscribedOttIds")
-    val subscribedOttIds: List<Long>,
+    @SerialName("agreedTermsIds")
+    val agreedTermsIds: List<Long>,
 )

--- a/app/src/main/java/com/flint/data/dto/auth/request/SignupRequestDto.kt
+++ b/app/src/main/java/com/flint/data/dto/auth/request/SignupRequestDto.kt
@@ -10,7 +10,7 @@ data class SignupRequestDto(
     @SerialName("nickname")
     val nickname: String,
     @SerialName("favoriteContentIds")
-    val favoriteContentIds: List<Long>,
+    val favoriteContentIds: List<String>,
     @SerialName("agreedTermsIds")
-    val agreedTermsIds: List<Long>,
+    val agreedTermsIds: List<String>,
 )

--- a/app/src/main/java/com/flint/data/dto/search/SearchContentsResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/search/SearchContentsResponseDto.kt
@@ -5,8 +5,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SearchContentsResponseDto(
-    @SerialName("contents")
-    val contents: List<Content>
+    @SerialName("data")
+    val data: List<Content>,
+    @SerialName("meta")
+    val meta: Meta? = null,
 ) {
     @Serializable
     data class Content(
@@ -19,6 +21,16 @@ data class SearchContentsResponseDto(
         @SerialName("posterUrl")
         val posterUrl: String,
         @SerialName("year")
-        val year: Int
+        val year: Int,
+    )
+
+    @Serializable
+    data class Meta(
+        @SerialName("type")
+        val type: String? = null,
+        @SerialName("returned")
+        val returned: Int? = null,
+        @SerialName("nextCursor")
+        val nextCursor: String? = null,
     )
 }

--- a/app/src/main/java/com/flint/data/dto/terms/response/TermResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/terms/response/TermResponseDto.kt
@@ -1,0 +1,22 @@
+package com.flint.data.dto.terms.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermResponseDto(
+    @SerialName("id")
+    val id: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("version")
+    val version: Int,
+    @SerialName("title")
+    val title: String,
+    @SerialName("content")
+    val content: String,
+    @SerialName("required")
+    val required: Boolean,
+    @SerialName("activeAt")
+    val activeAt: String,
+)

--- a/app/src/main/java/com/flint/data/dto/terms/response/TermsListResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/terms/response/TermsListResponseDto.kt
@@ -1,0 +1,10 @@
+package com.flint.data.dto.terms.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsListResponseDto(
+    @SerialName("terms")
+    val terms: List<TermResponseDto>,
+)

--- a/app/src/main/java/com/flint/domain/mapper/auth/SignupMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/auth/SignupMapper.kt
@@ -10,7 +10,7 @@ fun SignupRequestModel.toDto(): SignupRequestDto =
         tempToken = tempToken,
         nickname = nickname,
         favoriteContentIds = favoriteContentIds,
-        subscribedOttIds = subscribedOttIds,
+        agreedTermsIds = agreedTermsIds,
     )
 
 fun SignupResponseDto.toModel(): SignupResponseModel =

--- a/app/src/main/java/com/flint/domain/mapper/search/SearchContentMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/search/SearchContentMapper.kt
@@ -7,7 +7,7 @@ import kotlinx.collections.immutable.toImmutableList
 
 fun SearchContentsResponseDto.toModel(): SearchContentListModel {
     return SearchContentListModel(
-        contents = this.contents.map { it.toModel() }.toImmutableList()
+        contents = this.data.map { it.toModel() }.toImmutableList()
     )
 }
 

--- a/app/src/main/java/com/flint/domain/mapper/terms/TermsMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/terms/TermsMapper.kt
@@ -1,0 +1,17 @@
+package com.flint.domain.mapper.terms
+
+import com.flint.data.dto.terms.response.TermResponseDto
+import com.flint.domain.model.terms.TermModel
+
+fun TermResponseDto.toModel(): TermModel =
+    TermModel(
+        id = id.toLong(),
+        type = type,
+        version = version,
+        title = title,
+        content = content,
+        required = required,
+        activeAt = activeAt,
+    )
+
+fun List<TermResponseDto>.toModel(): List<TermModel> = map { it.toModel() }

--- a/app/src/main/java/com/flint/domain/mapper/terms/TermsMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/terms/TermsMapper.kt
@@ -5,7 +5,7 @@ import com.flint.domain.model.terms.TermModel
 
 fun TermResponseDto.toModel(): TermModel =
     TermModel(
-        id = id.toLong(),
+        id = id,
         type = type,
         version = version,
         title = title,

--- a/app/src/main/java/com/flint/domain/model/auth/SignupModel.kt
+++ b/app/src/main/java/com/flint/domain/model/auth/SignupModel.kt
@@ -4,7 +4,7 @@ data class SignupRequestModel(
     val tempToken: String,
     val nickname: String,
     val favoriteContentIds: List<Long>,
-    val subscribedOttIds: List<Long>,
+    val agreedTermsIds: List<Long>,
 )
 
 data class SignupResponseModel(

--- a/app/src/main/java/com/flint/domain/model/auth/SignupModel.kt
+++ b/app/src/main/java/com/flint/domain/model/auth/SignupModel.kt
@@ -3,8 +3,8 @@ package com.flint.domain.model.auth
 data class SignupRequestModel(
     val tempToken: String,
     val nickname: String,
-    val favoriteContentIds: List<Long>,
-    val agreedTermsIds: List<Long>,
+    val favoriteContentIds: List<String>,
+    val agreedTermsIds: List<String>,
 )
 
 data class SignupResponseModel(

--- a/app/src/main/java/com/flint/domain/model/terms/TermModel.kt
+++ b/app/src/main/java/com/flint/domain/model/terms/TermModel.kt
@@ -1,0 +1,11 @@
+package com.flint.domain.model.terms
+
+data class TermModel(
+    val id: Long,
+    val type: String,
+    val version: Int,
+    val title: String,
+    val content: String,
+    val required: Boolean,
+    val activeAt: String,
+)

--- a/app/src/main/java/com/flint/domain/model/terms/TermModel.kt
+++ b/app/src/main/java/com/flint/domain/model/terms/TermModel.kt
@@ -1,7 +1,7 @@
 package com.flint.domain.model.terms
 
 data class TermModel(
-    val id: Long,
+    val id: String,
     val type: String,
     val version: Int,
     val title: String,

--- a/app/src/main/java/com/flint/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/SearchRepository.kt
@@ -14,6 +14,18 @@ class SearchRepository @Inject constructor(
     suspend fun getBookmarkedContentList(keyword: String, cursor: Int, size: Int): Result<List<ContentModel>> =
         suspendRunCatching { apiService.getBookmarkedContentList(keyword, cursor, size).data.toModel() }
 
-    suspend fun getSearchContentList(keyword: String?): Result<SearchContentListModel> =
-        suspendRunCatching { apiService.getSearchContentList(keyword).data.toModel() }
+    suspend fun getSearchContentList(
+        keyword: String? = null,
+        genre: String? = null,
+        cursor: Int = 1,
+        size: Int = 20,
+    ): Result<SearchContentListModel> =
+        suspendRunCatching {
+            apiService.getSearchContentList(
+                keyword = keyword,
+                genre = genre,
+                cursor = cursor,
+                size = size,
+            ).data.toModel()
+        }
 }

--- a/app/src/main/java/com/flint/domain/repository/TermsRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/TermsRepository.kt
@@ -1,0 +1,16 @@
+package com.flint.domain.repository
+
+import com.flint.core.common.util.suspendRunCatching
+import com.flint.data.api.TermsApi
+import com.flint.domain.mapper.terms.toModel
+import com.flint.domain.model.terms.TermModel
+import javax.inject.Inject
+
+class TermsRepository @Inject constructor(
+    private val api: TermsApi,
+) {
+    suspend fun getTermsList(type: String? = null): Result<List<TermModel>> =
+        suspendRunCatching {
+            api.getTermsList(type).data.terms.toModel()
+        }
+}

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -171,8 +171,8 @@ fun OnboardingContentScreen(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            items(OnboardingContentUiState.GENRES) { genre ->
-                                val isSelected = genre in contentUiState.selectedGenres
+                            items(OnboardingContentUiState.GENRES.keys.toList()) { genre ->
+                                val isSelected = contentUiState.selectedGenre == genre
                                 FlintGenreChip(
                                     text = genre,
                                     isSelected = isSelected,
@@ -375,16 +375,14 @@ private fun OnboardingContentScreenEmptyPreview() {
 @Preview(showBackground = true, name = "장르 칩 인터랙티브")
 @Composable
 private fun OnboardingContentScreenGenreInteractivePreview() {
-    var selectedGenres by remember { mutableStateOf(setOf<String>()) }
+    var selectedGenre by remember { mutableStateOf<String?>(null) }
 
     FlintTheme {
         OnboardingContentScreen(
             nickname = "안비",
             contentUiState = OnboardingContentUiState(
                 searchResults = UiState.Success(SearchContentListModel.FakeList),
-                selectedGenres = selectedGenres.toList().let {
-                    kotlinx.collections.immutable.persistentListOf(*it.toTypedArray())
-                },
+                selectedGenre = selectedGenre,
             ),
             onBackClick = {},
             onNextClick = {},
@@ -394,11 +392,7 @@ private fun OnboardingContentScreenGenreInteractivePreview() {
             onContentClick = {},
             onRemoveContent = {},
             onGenreClick = { genre ->
-                selectedGenres = if (genre in selectedGenres) {
-                    selectedGenres - genre
-                } else {
-                    selectedGenres + genre
-                }
+                selectedGenre = if (selectedGenre == genre) null else genre
             },
         )
     }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
@@ -70,7 +70,7 @@ fun OnboardingTermsRoute(
 fun OnboardingTermsScreen(
     termsUiState: OnboardingTermsUiState,
     onBackClick: () -> Unit,
-    onAgreeClick: (List<Long>) -> Unit,
+    onAgreeClick: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val terms = (termsUiState.termsState as? UiState.Success)?.data ?: emptyList()
@@ -287,7 +287,7 @@ private fun OnboardingTermsScreenPreview() {
                 termsState = UiState.Success(
                     listOf(
                         TermModel(
-                            id = 1L,
+                            id = "1",
                             type = "SERVICE",
                             version = 1,
                             title = "서비스 이용약관",
@@ -296,7 +296,7 @@ private fun OnboardingTermsScreenPreview() {
                             activeAt = "2026-05-13T10:48:54.554Z",
                         ),
                         TermModel(
-                            id = 2L,
+                            id = "2",
                             type = "PRIVACY",
                             version = 1,
                             title = "개인정보 처리 방침",
@@ -305,7 +305,7 @@ private fun OnboardingTermsScreenPreview() {
                             activeAt = "2026-05-13T10:48:54.554Z",
                         ),
                         TermModel(
-                            id = 3L,
+                            id = "3",
                             type = "MARKETING",
                             version = 1,
                             title = "마케팅 정보 수신 동의",

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
@@ -2,6 +2,7 @@ package com.flint.presentation.onboarding
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -12,10 +13,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,63 +28,61 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flint.R
 import com.flint.core.common.extension.noRippleClickable
+import com.flint.core.common.util.UiState
 import com.flint.core.designsystem.component.button.FlintButtonState
 import com.flint.core.designsystem.component.button.FlintLargeButton
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
-
-private data class TermItem(
-    val title: String,
-    val description: String,
-    val detailUrl: String,
-)
-
-private val terms = listOf(
-    TermItem(
-        title = "(필수) 서비스 이용 약관 동의",
-        description = "본 약관은 서비스 이용과 관련한 기본적인 권리·의무 및 책임사항을 규정합니다.",
-        detailUrl = "",
-    ),
-    TermItem(
-        title = "(필수) 개인정보 처리 방침 동의",
-        description = "서비스 제공을 위해 개인정보를 수집·이용합니다.\n" +
-            "콘텐츠 추천, 컬렉션 생성 및 공유, 맞춤형 탐색 경험 제공을 위한 이용 기록 및 취향 정보 처리 내용이 포함됩니다.\n\n" +
-            "수집 항목: 계정 정보, 취향 정보, 컬렉션 및 콘텐츠 활동, 서비스 이용 기록 등\n\n" +
-            "수집 목적: 개인화 추천 제공, 컬렉션 생성 및 공유, 서비스 운영 및 이용자 보호",
-        detailUrl = "",
-    ),
-)
+import com.flint.domain.model.terms.TermModel
 
 @Composable
 fun OnboardingTermsRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
     navigateToOnboardingContent: () -> Unit,
+    viewModel: OnboardingViewModel,
 ) {
+    val termsUiState by viewModel.termsUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadTerms()
+    }
+
     OnboardingTermsScreen(
+        termsUiState = termsUiState,
         onBackClick = navigateUp,
-        onAgreeClick = navigateToOnboardingContent,
+        onAgreeClick = { agreedIds ->
+            viewModel.agreeToTerms(agreedIds)
+            navigateToOnboardingContent()
+        },
         modifier = Modifier.padding(paddingValues),
     )
 }
 
 @Composable
 fun OnboardingTermsScreen(
+    termsUiState: OnboardingTermsUiState,
     onBackClick: () -> Unit,
-    onAgreeClick: () -> Unit,
+    onAgreeClick: (List<Long>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var checkedStates by remember { mutableStateOf(List(terms.size) { false }) }
-    var expandedStates by remember { mutableStateOf(List(terms.size) { false }) }
-    val allChecked = checkedStates.all { it }
-    val uriHandler = LocalUriHandler.current
+    val terms = (termsUiState.termsState as? UiState.Success)?.data ?: emptyList()
+    var checkedStates by remember(terms) { mutableStateOf(List(terms.size) { false }) }
+    var expandedStates by remember(terms) { mutableStateOf(List(terms.size) { false }) }
+
+    // 필수 약관이 모두 체크되어야 버튼 활성화
+    val requiredAllChecked = terms.isNotEmpty() && terms.indices
+        .filter { terms[it].required }
+        .all { checkedStates[it] }
+
+    val allChecked = terms.isNotEmpty() && checkedStates.all { it }
 
     Column(
         modifier = modifier
@@ -132,34 +133,71 @@ fun OnboardingTermsScreen(
 
             HorizontalDivider(thickness = 4.dp, color = FlintTheme.colors.gray600)
 
-            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                Spacer(Modifier.height(16.dp))
+            when (termsUiState.termsState) {
+                is UiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(color = FlintTheme.colors.primary200)
+                    }
+                }
 
-                terms.forEachIndexed { index, term ->
-                    TermRow(
-                        term = term,
-                        isChecked = checkedStates[index],
-                        isExpanded = expandedStates[index],
-                        onCheckClick = {
-                            checkedStates = checkedStates.toMutableList().also { it[index] = !it[index] }
-                        },
-                        onExpandClick = {
-                            expandedStates = expandedStates.toMutableList().also { it[index] = !it[index] }
-                        },
-                        onDetailClick = {
-                            if (term.detailUrl.isNotEmpty()) uriHandler.openUri(term.detailUrl)
-                        },
-                    )
-                    Spacer(Modifier.height(4.dp))
+                is UiState.Failure -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "약관을 불러오지 못했습니다.",
+                            style = FlintTheme.typography.body1R16,
+                            color = FlintTheme.colors.gray400,
+                        )
+                    }
+                }
+
+                else -> {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        Spacer(Modifier.height(16.dp))
+
+                        terms.forEachIndexed { index, term ->
+                            TermRow(
+                                term = term,
+                                isChecked = checkedStates[index],
+                                isExpanded = expandedStates[index],
+                                onCheckClick = {
+                                    checkedStates = checkedStates.toMutableList()
+                                        .also { it[index] = !it[index] }
+                                },
+                                onExpandClick = {
+                                    expandedStates = expandedStates.toMutableList()
+                                        .also { it[index] = !it[index] }
+                                },
+                                onDetailClick = {
+                                    // TODO: 노션 약관 링크 확정 후 내부 웹뷰로 열기
+                                },
+                            )
+                            Spacer(Modifier.height(4.dp))
+                        }
+                    }
                 }
             }
         }
 
         FlintLargeButton(
             text = "동의하기",
-            state = if (allChecked) FlintButtonState.Able else FlintButtonState.Disable,
-            onClick = onAgreeClick,
-            enabled = allChecked,
+            state = if (requiredAllChecked) FlintButtonState.Able else FlintButtonState.Disable,
+            onClick = {
+                val agreedIds = terms.indices
+                    .filter { checkedStates[it] }
+                    .map { terms[it].id }
+                onAgreeClick(agreedIds)
+            },
+            enabled = requiredAllChecked,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 20.dp),
@@ -169,13 +207,15 @@ fun OnboardingTermsScreen(
 
 @Composable
 private fun TermRow(
-    term: TermItem,
+    term: TermModel,
     isChecked: Boolean,
     isExpanded: Boolean,
     onCheckClick: () -> Unit,
     onExpandClick: () -> Unit,
     onDetailClick: () -> Unit,
 ) {
+    val requiredPrefix = if (term.required) "(필수) " else "(선택) "
+
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
@@ -193,7 +233,7 @@ private fun TermRow(
             )
             Spacer(Modifier.width(12.dp))
             Text(
-                text = term.title,
+                text = requiredPrefix + term.title,
                 style = FlintTheme.typography.body1R16,
                 color = FlintTheme.colors.white,
                 modifier = Modifier.weight(1f),
@@ -219,7 +259,7 @@ private fun TermRow(
                     .padding(start = 12.dp, top = 12.dp, end = 12.dp, bottom = 16.dp),
             ) {
                 Text(
-                    text = term.description,
+                    text = term.content,
                     style = FlintTheme.typography.body2R14,
                     color = FlintTheme.colors.gray300,
                 )
@@ -243,6 +283,39 @@ private fun TermRow(
 private fun OnboardingTermsScreenPreview() {
     FlintTheme {
         OnboardingTermsScreen(
+            termsUiState = OnboardingTermsUiState(
+                termsState = UiState.Success(
+                    listOf(
+                        TermModel(
+                            id = 1L,
+                            type = "SERVICE",
+                            version = 1,
+                            title = "서비스 이용약관",
+                            content = "본 약관은 서비스 이용과 관련한 기본적인 권리·의무 및 책임사항을 규정합니다.",
+                            required = true,
+                            activeAt = "2026-05-13T10:48:54.554Z",
+                        ),
+                        TermModel(
+                            id = 2L,
+                            type = "PRIVACY",
+                            version = 1,
+                            title = "개인정보 처리 방침",
+                            content = "서비스 제공을 위해 개인정보를 수집·이용합니다.",
+                            required = true,
+                            activeAt = "2026-05-13T10:48:54.554Z",
+                        ),
+                        TermModel(
+                            id = 3L,
+                            type = "MARKETING",
+                            version = 1,
+                            title = "마케팅 정보 수신 동의",
+                            content = "이벤트 및 마케팅 정보를 수신합니다.",
+                            required = false,
+                            activeAt = "2026-05-13T10:48:54.554Z",
+                        ),
+                    )
+                )
+            ),
             onBackClick = {},
             onAgreeClick = {},
         )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -9,7 +9,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 data class OnboardingTermsUiState(
     val termsState: UiState<List<TermModel>> = UiState.Empty,
-    val agreedTermsIds: List<Long> = emptyList(),
+    val agreedTermsIds: List<String> = emptyList(),
 )
 
 enum class NicknameErrorType {

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -48,13 +48,19 @@ data class OnboardingContentUiState(
     val searchResults: UiState<ImmutableList<SearchContentItemModel>> = UiState.Empty,
     val selectedContents: ImmutableList<SearchContentItemModel> = persistentListOf(),
     val isSearching: Boolean = false,
-    val selectedGenres: ImmutableList<String> = persistentListOf(),
+    val selectedGenre: String? = null,
 ) {
     companion object {
         const val REQUIRED_SELECTION_COUNT = 7
 
-        val GENRES = listOf(
-            "액션", "로맨스", "SF", "드라마", "코미디", "호러"
+        // 표시용(Korean) → API enum 매핑
+        val GENRES: Map<String, String> = linkedMapOf(
+            "액션" to "ACTION",
+            "로맨스" to "ROMANCE",
+            "SF" to "SCIENCE_FICTION",
+            "드라마" to "DRAMA",
+            "코미디" to "COMEDY",
+            "호러" to "HORROR",
         )
     }
 

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -2,9 +2,15 @@ package com.flint.presentation.onboarding
 
 import com.flint.core.common.util.UiState
 import com.flint.domain.model.search.SearchContentItemModel
+import com.flint.domain.model.terms.TermModel
 import com.flint.domain.type.OttType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+
+data class OnboardingTermsUiState(
+    val termsState: UiState<List<TermModel>> = UiState.Empty,
+    val agreedTermsIds: List<Long> = emptyList(),
+)
 
 enum class NicknameErrorType {
     DUPLICATE,      // 이미 사용 중인 닉네임

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -185,7 +185,8 @@ class OnboardingViewModel
                 tempToken = tempToken,
                 nickname = _uiState.value.nickname,
                 favoriteContentIds = _contentUiState.value.selectedContents.map { it.id.toLong() },
-                subscribedOttIds = _ottUiState.value.selectedOtts.map { it.id }
+                // TODO: 약관 동의 화면 구현 후 실제 동의한 약관 ID로 변경 (임시 하드코딩)
+                agreedTermsIds = listOf(1L, 2L),
             )
 
             authRepository.signup(signupRequest)

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -9,6 +9,7 @@ import com.flint.core.navigation.Route
 import com.flint.domain.model.auth.SignupRequestModel
 import com.flint.domain.repository.AuthRepository
 import com.flint.domain.repository.SearchRepository
+import com.flint.domain.repository.TermsRepository
 import com.flint.domain.repository.UserRepository
 import com.flint.domain.type.OttType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,6 +29,7 @@ class OnboardingViewModel
     private val userRepository: UserRepository,
     private val searchRepository: SearchRepository,
     private val authRepository: AuthRepository,
+    private val termsRepository: TermsRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -42,8 +44,34 @@ class OnboardingViewModel
     private val _ottUiState = MutableStateFlow(OnboardingOttUiState())
     val ottUiState: StateFlow<OnboardingOttUiState> = _ottUiState.asStateFlow()
 
+    private val _termsUiState = MutableStateFlow(OnboardingTermsUiState())
+    val termsUiState: StateFlow<OnboardingTermsUiState> = _termsUiState.asStateFlow()
+
     private val _signupUiState = MutableStateFlow(OnboardingSignupUiState())
     val signupUiState: StateFlow<OnboardingSignupUiState> = _signupUiState.asStateFlow()
+
+    // ---------- onboarding terms ----------
+    fun loadTerms() {
+        if (_termsUiState.value.termsState is UiState.Loading ||
+            _termsUiState.value.termsState is UiState.Success
+        ) return
+
+        viewModelScope.launch {
+            _termsUiState.update { it.copy(termsState = UiState.Loading) }
+            termsRepository.getTermsList()
+                .onSuccess { terms ->
+                    _termsUiState.update { it.copy(termsState = UiState.Success(terms)) }
+                }
+                .onFailure { error ->
+                    _termsUiState.update { it.copy(termsState = UiState.Failure) }
+                    Timber.e(error, "Failed to load terms")
+                }
+        }
+    }
+
+    fun agreeToTerms(termIds: List<Long>) {
+        _termsUiState.update { it.copy(agreedTermsIds = termIds) }
+    }
 
     // ---------- onboarding profile ----------
     fun updateNickname(nickname: String) {
@@ -190,8 +218,7 @@ class OnboardingViewModel
                 tempToken = tempToken,
                 nickname = _uiState.value.nickname,
                 favoriteContentIds = _contentUiState.value.selectedContents.map { it.id.toLong() },
-                // TODO: 약관 동의 화면 구현 후 실제 동의한 약관 ID로 변경 (임시 하드코딩)
-                agreedTermsIds = listOf(1L, 2L),
+                agreedTermsIds = _termsUiState.value.agreedTermsIds,
             )
 
             authRepository.signup(signupRequest)

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -103,31 +103,36 @@ class OnboardingViewModel
     }
 
     fun loadInitialContents() {
-        getSearchContentList(null)
+        getSearchContentList(keyword = null, genre = null)
     }
 
     fun searchContents() {
-        val keyword = _contentUiState.value.searchKeyword
-        getSearchContentList(keyword.ifEmpty { null })
+        val keyword = _contentUiState.value.searchKeyword.ifEmpty { null }
+        val genre = _contentUiState.value.selectedGenre
+        getSearchContentList(keyword = keyword, genre = genre)
     }
 
     fun selectGenre(genre: String) {
         _contentUiState.update { currentState ->
-            val current = currentState.selectedGenres
-            val newSelectedGenres = if (genre in current) {
-                current.filterNot { it == genre }.toImmutableList()
-            } else {
-                (current + genre).toImmutableList()
-            }
-            currentState.copy(selectedGenres = newSelectedGenres)
+            val newSelected = if (currentState.selectedGenre == genre) null else genre
+            currentState.copy(selectedGenre = newSelected)
         }
+        // 장르 선택/해제 시 즉시 재검색
+        val keyword = _contentUiState.value.searchKeyword.ifEmpty { null }
+        val selected = _contentUiState.value.selectedGenre
+        getSearchContentList(keyword = keyword, genre = selected)
     }
 
-    private fun getSearchContentList(keyword: String?) {
+    private fun getSearchContentList(keyword: String?, genre: String?) {
         viewModelScope.launch {
             _contentUiState.update { it.copy(searchResults = UiState.Loading) }
 
-            searchRepository.getSearchContentList(keyword)
+            val genreApiValue = genre?.let { OnboardingContentUiState.GENRES[it] }
+
+            searchRepository.getSearchContentList(
+                keyword = keyword,
+                genre = genreApiValue,
+            )
                 .onSuccess { result ->
                     _contentUiState.update { currentState ->
                         currentState.copy(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -50,6 +51,8 @@ class OnboardingViewModel
     private val _signupUiState = MutableStateFlow(OnboardingSignupUiState())
     val signupUiState: StateFlow<OnboardingSignupUiState> = _signupUiState.asStateFlow()
 
+    private var searchJob: Job? = null
+
     // ---------- onboarding terms ----------
     fun loadTerms() {
         if (_termsUiState.value.termsState is UiState.Loading ||
@@ -69,7 +72,7 @@ class OnboardingViewModel
         }
     }
 
-    fun agreeToTerms(termIds: List<Long>) {
+    fun agreeToTerms(termIds: List<String>) {
         _termsUiState.update { it.copy(agreedTermsIds = termIds) }
     }
 
@@ -152,7 +155,8 @@ class OnboardingViewModel
     }
 
     private fun getSearchContentList(keyword: String?, genre: String?) {
-        viewModelScope.launch {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
             _contentUiState.update { it.copy(searchResults = UiState.Loading) }
 
             val genreApiValue = genre?.let { OnboardingContentUiState.GENRES[it] }
@@ -217,7 +221,7 @@ class OnboardingViewModel
             val signupRequest = SignupRequestModel(
                 tempToken = tempToken,
                 nickname = _uiState.value.nickname,
-                favoriteContentIds = _contentUiState.value.selectedContents.map { it.id.toLong() },
+                favoriteContentIds = _contentUiState.value.selectedContents.map { it.id },
                 agreedTermsIds = _termsUiState.value.agreedTermsIds,
             )
 

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -55,6 +55,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
                 navigateToOnboardingContent = navController::navigateToOnboardingContent,
+                viewModel = sharedViewModel,
             )
         }
 


### PR DESCRIPTION
## 📮 관련 이슈
Flt 16 회원가입 api 수정

## 📌 작업 내용
- 약관동의 api연결 
- 회원가입 api 수정(약관동의 id)
- 온보딩 api 수정(장르 칩)

## 📸 스크린샷
| 온보딩 콘텐츠 선택 | 약관동의 |
|:--:|:--:|
|<img width="638" height="1346" alt="image" src="https://github.com/user-attachments/assets/865116d6-00d5-458a-86db-45db6eccc409" /> |<img width="638" height="1346" alt="image" src="https://github.com/user-attachments/assets/fb060aaa-2f08-44eb-b58f-63fb1e4c42ff" />|


## 😅 미구현
- [ ] 서버명세엔 장르칩이 단일로 바껴서, 맞게 수정했는데, 다시 다중으로 명세 변경 될 예정이라 그에 맞출 예정

## 🫛 To. 리뷰어
온보딩에서 장르 칩을  클릭해 정보를 가져오기 전에 다른 장르칩을 클릭하면  이전 요청이 취소되면서 OkHttp가 던지는 IOException을 NetworkErrorInterceptor가 실제 네트워크 오류로 잘못인식해
"문제가 발생했어요" 모달이 노출되는 문제가 있어서
chain.call().isCanceled() 체크를 추가해 의도적 취소는 에러 emit 없이 넘기도록 수정했습니당


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검색 기능에 장르 필터 옵션 추가
  * 회원가입 시 약관 동의 프로세스 추가
  * 온보딩 약관 동의 화면 개선 및 동적 약관 로드 기능 구현

* **Improvements**
  * 장르 선택을 다중 선택에서 단일 선택으로 변경
  * 검색 결과 페이지네이션 기본값 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imflint/Flint-Android/pull/206)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->