### PR TITLE
feat: 온보딩 프로필 이미지 등록 및 UX 개선

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/toast/ShowToast.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/toast/ShowToast.kt
@@ -3,6 +3,7 @@ package com.flint.core.designsystem.component.toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,7 +37,9 @@ fun ShowToast(
     }
 
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding(),
         contentAlignment = Alignment.BottomCenter,
     ) {
         FlintToast(

--- a/app/src/main/java/com/flint/core/navigation/Route.kt
+++ b/app/src/main/java/com/flint/core/navigation/Route.kt
@@ -11,9 +11,7 @@ interface Route {
     data object Login : Route
 
     @Serializable
-    data class OnboardingProfile(
-        val tempToken: String
-    ) : Route
+    data object OnboardingProfile : Route
 
     @Serializable
     data class OnboardingGraph(

--- a/app/src/main/java/com/flint/data/api/AuthApi.kt
+++ b/app/src/main/java/com/flint/data/api/AuthApi.kt
@@ -21,6 +21,6 @@ interface AuthApi {
         @Body requestDto: SocialVerifyRequestDto,
     ): BaseResponse<SocialVerifyResponseDto>
 
-    @DELETE("/api/v1/auth/withdraw")
+    @POST("/api/v1/auth/withdraw")
     suspend fun withdraw(): WithdrawResponseDto
 }

--- a/app/src/main/java/com/flint/data/api/SearchApi.kt
+++ b/app/src/main/java/com/flint/data/api/SearchApi.kt
@@ -17,8 +17,9 @@ interface SearchApi {
     @GET("/api/v1/contents/search")
     suspend fun getSearchContentList(
         @Query("keyword") keyword: String? = null,
-        @Query("genre") genre: String? = null,
-        @Query("cursor") cursor: Int = 1,
+        @Query("genre") genre: List<String>? = null,
+        @Query("mediaType") mediaType: String? = null,
+        @Query("cursor") cursor: String? = null,
         @Query("size") size: Int = 20,
     ): BaseResponse<SearchContentsResponseDto>
 }

--- a/app/src/main/java/com/flint/data/api/StorageApi.kt
+++ b/app/src/main/java/com/flint/data/api/StorageApi.kt
@@ -1,6 +1,5 @@
 package com.flint.data.api
 
-import com.flint.data.dto.base.BaseResponse
 import com.flint.data.dto.storage.response.PresignedUrlResponseDto
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -11,5 +10,5 @@ interface StorageApi {
     suspend fun getPresignedUrl(
         @Query("pathType") pathType: String,
         @Query("extension") extension: String,
-    ): BaseResponse<PresignedUrlResponseDto>
+    ): PresignedUrlResponseDto
 }

--- a/app/src/main/java/com/flint/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/flint/data/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.flint.data.di
 import com.flint.BuildConfig
 import com.flint.data.di.interceptor.NetworkErrorInterceptor
 import com.flint.data.di.interceptor.TokenInterceptor
+import com.flint.data.di.qualifier.S3OkHttpClient
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -57,6 +58,18 @@ object NetworkModule {
                 addInterceptor(networkErrorInterceptor)
                 addInterceptor(tokenInterceptor)
                 addInterceptor(loggingInterceptor)
+            }.build()
+
+    @Provides
+    @Singleton
+    @S3OkHttpClient
+    fun provideS3OkHttpClient(): OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .apply {
+                connectTimeout(20, TimeUnit.SECONDS)
+                writeTimeout(60, TimeUnit.SECONDS)
+                readTimeout(20, TimeUnit.SECONDS)
             }.build()
 
     @Provides

--- a/app/src/main/java/com/flint/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/flint/data/di/NetworkModule.kt
@@ -63,13 +63,14 @@ object NetworkModule {
     @Provides
     @Singleton
     @S3OkHttpClient
-    fun provideS3OkHttpClient(): OkHttpClient =
+    fun provideS3OkHttpClient(loggingInterceptor: HttpLoggingInterceptor): OkHttpClient =
         OkHttpClient
             .Builder()
             .apply {
                 connectTimeout(20, TimeUnit.SECONDS)
                 writeTimeout(60, TimeUnit.SECONDS)
                 readTimeout(20, TimeUnit.SECONDS)
+                addInterceptor(loggingInterceptor)
             }.build()
 
     @Provides

--- a/app/src/main/java/com/flint/data/di/interceptor/TokenInterceptor.kt
+++ b/app/src/main/java/com/flint/data/di/interceptor/TokenInterceptor.kt
@@ -23,7 +23,8 @@ class TokenInterceptor
 
             val requestBuilder = originalRequest.newBuilder()
 
-            if (accessToken.isNotEmpty()) {
+            val isSearchRequest = originalRequest.url.encodedPath.endsWith("/contents/search")
+            if (accessToken.isNotEmpty() && !isSearchRequest) {
                 requestBuilder.header("Authorization", "Bearer $accessToken")
             }
 

--- a/app/src/main/java/com/flint/data/di/qualifier/S3OkHttpClient.kt
+++ b/app/src/main/java/com/flint/data/di/qualifier/S3OkHttpClient.kt
@@ -1,0 +1,7 @@
+package com.flint.data.di.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class S3OkHttpClient

--- a/app/src/main/java/com/flint/data/dto/auth/request/SignupRequestDto.kt
+++ b/app/src/main/java/com/flint/data/dto/auth/request/SignupRequestDto.kt
@@ -13,4 +13,6 @@ data class SignupRequestDto(
     val favoriteContentIds: List<String>,
     @SerialName("agreedTermsIds")
     val agreedTermsIds: List<String>,
+    @SerialName("profileImageUrl")
+    val profileImageUrl: String? = null,
 )

--- a/app/src/main/java/com/flint/data/dto/search/SearchContentsResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/search/SearchContentsResponseDto.kt
@@ -32,5 +32,13 @@ data class SearchContentsResponseDto(
         val returned: Int? = null,
         @SerialName("nextCursor")
         val nextCursor: String? = null,
+        @SerialName("page")
+        val page: Int? = null,
+        @SerialName("size")
+        val size: Int? = null,
+        @SerialName("totalElements")
+        val totalElements: String? = null,
+        @SerialName("totalPages")
+        val totalPages: Int? = null,
     )
 }

--- a/app/src/main/java/com/flint/domain/mapper/auth/SignupMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/auth/SignupMapper.kt
@@ -11,6 +11,7 @@ fun SignupRequestModel.toDto(): SignupRequestDto =
         nickname = nickname,
         favoriteContentIds = favoriteContentIds,
         agreedTermsIds = agreedTermsIds,
+        profileImageUrl = profileImageUrl,
     )
 
 fun SignupResponseDto.toModel(): SignupResponseModel =

--- a/app/src/main/java/com/flint/domain/model/auth/SignupModel.kt
+++ b/app/src/main/java/com/flint/domain/model/auth/SignupModel.kt
@@ -5,6 +5,7 @@ data class SignupRequestModel(
     val nickname: String,
     val favoriteContentIds: List<String>,
     val agreedTermsIds: List<String>,
+    val profileImageUrl: String? = null,
 )
 
 data class SignupResponseModel(

--- a/app/src/main/java/com/flint/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/SearchRepository.kt
@@ -16,14 +16,16 @@ class SearchRepository @Inject constructor(
 
     suspend fun getSearchContentList(
         keyword: String? = null,
-        genre: String? = null,
-        cursor: Int = 1,
+        genre: List<String>? = null,
+        mediaType: String? = null,
+        cursor: String? = null,
         size: Int = 20,
     ): Result<SearchContentListModel> =
         suspendRunCatching {
             apiService.getSearchContentList(
                 keyword = keyword,
                 genre = genre,
+                mediaType = mediaType,
                 cursor = cursor,
                 size = size,
             ).data.toModel()

--- a/app/src/main/java/com/flint/domain/repository/StorageRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/StorageRepository.kt
@@ -2,16 +2,23 @@ package com.flint.domain.repository
 
 import com.flint.core.common.util.suspendRunCatching
 import com.flint.data.api.StorageApi
+import com.flint.data.di.qualifier.S3OkHttpClient
 import com.flint.domain.mapper.storage.toModel
 import com.flint.domain.model.storage.PresignedUrlModel
 import com.flint.domain.type.FileExtension
 import com.flint.domain.type.StoragePathType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 
 class StorageRepository @Inject constructor(
     private val api: StorageApi,
+    @S3OkHttpClient private val s3Client: OkHttpClient,
 ) {
-    // Presigned URL 발급
     suspend fun getPresignedUrl(
         pathType: StoragePathType,
         extension: FileExtension,
@@ -22,4 +29,21 @@ class StorageRepository @Inject constructor(
                 extension = extension.name,
             ).data.toModel()
         }
+
+    suspend fun uploadToS3(
+        uploadUrl: String,
+        imageBytes: ByteArray,
+        mimeType: String,
+    ): Result<Unit> = suspendRunCatching {
+        withContext(Dispatchers.IO) {
+            val requestBody = imageBytes.toRequestBody(mimeType.toMediaTypeOrNull())
+            val request = Request.Builder()
+                .url(uploadUrl)
+                .put(requestBody)
+                .build()
+            s3Client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) error("S3 upload failed: ${response.code}")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/flint/domain/repository/StorageRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/StorageRepository.kt
@@ -27,7 +27,7 @@ class StorageRepository @Inject constructor(
             api.getPresignedUrl(
                 pathType = pathType.name,
                 extension = extension.name,
-            ).data.toModel()
+            ).toModel()
         }
 
     suspend fun uploadToS3(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -67,9 +67,11 @@ fun OnboardingProfileRoute(
         canProceed = uiState.canProceed,
         hasError = uiState.hasError,
         errorMessage = uiState.errorMessage,
+        profileImageUri = uiState.profileImageUri,
         onNicknameChange = viewModel::updateNickname,
         onCheckNickname = viewModel::checkNicknameDuplication,
         onClearError = viewModel::clearNicknameError,
+        onProfileImageSelected = viewModel::updateProfileImage,
         onBackClick = navigateUp,
         onNextClick = navigateToOnboardingContent,
         modifier = Modifier.padding(paddingValues),
@@ -86,9 +88,11 @@ fun OnboardingProfileScreen(
     canProceed: Boolean,
     hasError: Boolean,
     errorMessage: String?,
+    profileImageUri: Uri?,
     onNicknameChange: (String) -> Unit,
     onCheckNickname: () -> Unit,
     onClearError: () -> Unit,
+    onProfileImageSelected: (Uri?) -> Unit,
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -98,12 +102,11 @@ fun OnboardingProfileScreen(
     var toastMessage by remember { mutableStateOf("") }
     var isToastSuccess by remember { mutableStateOf(false) }
     var showProfileBottomSheet by remember { mutableStateOf(false) }
-    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
 
     val galleryLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia()
     ) { uri ->
-        if (uri != null) selectedImageUri = uri
+        if (uri != null) onProfileImageSelected(uri)
     }
 
     LaunchedEffect(hasError, errorMessage) {
@@ -140,7 +143,7 @@ fun OnboardingProfileScreen(
             ) {
 
                 EditProfileImage(
-                    imageUrl = selectedImageUri?.toString() ?: "",
+                    imageUrl = profileImageUri?.toString() ?: "",
                     onEditClick = { showProfileBottomSheet = true }
                 )
 
@@ -235,7 +238,7 @@ fun OnboardingProfileScreen(
                     MenuBottomSheetData(
                         label = "프로필 사진 삭제",
                         color = FlintTheme.colors.error500,
-                        clickAction = { selectedImageUri = null }
+                        clickAction = { onProfileImageSelected(null) }
                     ),
                 ),
                 onDismiss = { showProfileBottomSheet = false }
@@ -273,9 +276,11 @@ private fun OnboardingProfileScreenPreview() {
             canProceed = true,
             hasError = false,
             errorMessage = null,
+            profileImageUri = null,
             onNicknameChange = {},
             onCheckNickname = {},
             onClearError = {},
+            onProfileImageSelected = {},
             onBackClick = {},
             onNextClick = {},
         )
@@ -294,9 +299,11 @@ private fun OnboardingProfileScreenDuplicateErrorPreview() {
             canProceed = false,
             hasError = true,
             errorMessage = "이미 사용 중인 닉네임입니다",
+            profileImageUri = null,
             onNicknameChange = {},
             onCheckNickname = {},
             onClearError = {},
+            onProfileImageSelected = {},
             onBackClick = {},
             onNextClick = {},
         )
@@ -317,9 +324,11 @@ private fun OnboardingProfileScreenFormatErrorPreview() {
             canProceed = false,
             hasError = true,
             errorMessage = "사용할 수 없는 닉네임입니다",
+            profileImageUri = null,
             onNicknameChange = { text = it },
             onCheckNickname = {},
             onClearError = {},
+            onProfileImageSelected = {},
             onBackClick = {},
             onNextClick = {},
         )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -65,16 +68,18 @@ fun OnboardingProfileRoute(
         isFormatValid = uiState.isFormatValid,
         isNicknameAvailable = uiState.isNicknameAvailable,
         canProceed = uiState.canProceed,
+        canCheckNickname = uiState.canCheckNickname,
         hasError = uiState.hasError,
         errorMessage = uiState.errorMessage,
         profileImageUri = uiState.profileImageUri,
         onNicknameChange = viewModel::updateNickname,
         onCheckNickname = viewModel::checkNicknameDuplication,
-        onClearError = viewModel::clearNicknameError,
         onProfileImageSelected = viewModel::updateProfileImage,
         onBackClick = navigateUp,
         onNextClick = navigateToOnboardingContent,
-        modifier = Modifier.padding(paddingValues),
+        modifier = Modifier
+            .padding(paddingValues)
+            .consumeWindowInsets(paddingValues),
     )
 }
 
@@ -86,12 +91,12 @@ fun OnboardingProfileScreen(
     isFormatValid: Boolean,
     isNicknameAvailable: Boolean?,
     canProceed: Boolean,
+    canCheckNickname: Boolean,
     hasError: Boolean,
     errorMessage: String?,
     profileImageUri: Uri?,
     onNicknameChange: (String) -> Unit,
     onCheckNickname: () -> Unit,
-    onClearError: () -> Unit,
     onProfileImageSelected: (Uri?) -> Unit,
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
@@ -130,6 +135,7 @@ fun OnboardingProfileScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .background(color = FlintTheme.colors.background)
+                .imePadding()
         ) {
             FlintBackTopAppbar(
                 onClick = onBackClick,
@@ -194,10 +200,10 @@ fun OnboardingProfileScreen(
                             .fillMaxHeight()
                             .clip(RoundedCornerShape(8.dp))
                             .background(
-                                if (isValid && isFormatValid) FlintTheme.colors.primary400
+                                if (canCheckNickname) FlintTheme.colors.primary400
                                 else FlintTheme.colors.gray700
                             )
-                            .clickable(enabled = isValid && isFormatValid) {
+                            .clickable(enabled = canCheckNickname) {
                                 keyboardController?.hide()
                                 onCheckNickname()
                             }
@@ -206,8 +212,8 @@ fun OnboardingProfileScreen(
                     ) {
                         Text(
                             text = "확인",
-                            color = if (isValid && isFormatValid) FlintTheme.colors.white else FlintTheme.colors.gray400,
-                            style = if (isValid && isFormatValid) FlintTheme.typography.body1Sb16 else FlintTheme.typography.body1M16,
+                            color = if (canCheckNickname) FlintTheme.colors.white else FlintTheme.colors.gray400,
+                            style = if (canCheckNickname) FlintTheme.typography.body1Sb16 else FlintTheme.typography.body1M16,
                         )
                     }
                 }
@@ -253,12 +259,7 @@ fun OnboardingProfileScreen(
                 ),
                 paddingValues = PaddingValues.Zero,
                 yOffset = 100.dp,
-                hide = {
-                    showToast = false
-                    if (!isToastSuccess) {
-                        onClearError()
-                    }
-                },
+                hide = { showToast = false },
             )
         }
     }
@@ -274,12 +275,12 @@ private fun OnboardingProfileScreenPreview() {
             isFormatValid = true,
             isNicknameAvailable = true,
             canProceed = true,
+            canCheckNickname = true,
             hasError = false,
             errorMessage = null,
             profileImageUri = null,
             onNicknameChange = {},
             onCheckNickname = {},
-            onClearError = {},
             onProfileImageSelected = {},
             onBackClick = {},
             onNextClick = {},
@@ -297,12 +298,12 @@ private fun OnboardingProfileScreenDuplicateErrorPreview() {
             isFormatValid = true,
             isNicknameAvailable = false,
             canProceed = false,
+            canCheckNickname = true,
             hasError = true,
             errorMessage = "이미 사용 중인 닉네임입니다",
             profileImageUri = null,
             onNicknameChange = {},
             onCheckNickname = {},
-            onClearError = {},
             onProfileImageSelected = {},
             onBackClick = {},
             onNextClick = {},
@@ -322,12 +323,12 @@ private fun OnboardingProfileScreenFormatErrorPreview() {
             isFormatValid = false,
             isNicknameAvailable = null,
             canProceed = false,
+            canCheckNickname = false,
             hasError = true,
             errorMessage = "사용할 수 없는 닉네임입니다",
             profileImageUri = null,
             onNicknameChange = { text = it },
             onCheckNickname = {},
-            onClearError = {},
             onProfileImageSelected = {},
             onBackClick = {},
             onNextClick = {},

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
@@ -48,7 +48,7 @@ import com.flint.domain.model.terms.TermModel
 fun OnboardingTermsRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
-    navigateToOnboardingContent: () -> Unit,
+    navigateToOnboardingProfile: () -> Unit,
     viewModel: OnboardingViewModel,
 ) {
     val termsUiState by viewModel.termsUiState.collectAsStateWithLifecycle()
@@ -62,7 +62,7 @@ fun OnboardingTermsRoute(
         onBackClick = navigateUp,
         onAgreeClick = { agreedIds ->
             viewModel.agreeToTerms(agreedIds)
-            navigateToOnboardingContent()
+            navigateToOnboardingProfile()
         },
         modifier = Modifier.padding(paddingValues),
     )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
@@ -2,6 +2,8 @@ package com.flint.presentation.onboarding
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -161,7 +163,11 @@ fun OnboardingTermsScreen(
                 }
 
                 else -> {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    Column(
+                        modifier = Modifier
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = 16.dp),
+                    ) {
                         Spacer(Modifier.height(16.dp))
 
                         terms.forEachIndexed { index, term ->

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -29,12 +29,16 @@ data class OnboardingProfileUiState(
     companion object {
         const val MAX_LENGTH = 8
         const val MIN_LENGTH = 2
-        private val NICKNAME_REGEX = Regex("^[가-힣a-zA-Z]+$")
+        private val NICKNAME_REGEX = Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z]+$")
+        private val STANDALONE_KOREAN_REGEX = Regex("[ㄱ-ㅎㅏ-ㅣ]")
 
         fun isValidFormat(nickname: String): Boolean {
             return nickname.isEmpty() || NICKNAME_REGEX.matches(nickname)
         }
     }
+
+    val hasStandaloneKorean: Boolean
+        get() = STANDALONE_KOREAN_REGEX.containsMatchIn(nickname)
 
     val hasError: Boolean
         get() = nicknameErrorType != null
@@ -46,9 +50,12 @@ data class OnboardingProfileUiState(
             null -> null
         }
 
+    val canCheckNickname: Boolean
+        get() = isValid && isFormatValid && !hasStandaloneKorean
+
     //다음단계 활성화
     val canProceed: Boolean
-        get() = isValid && isFormatValid && isNicknameAvailable == true
+        get() = isValid && isFormatValid && isNicknameAvailable == true && !hasStandaloneKorean
 }
 
 data class OnboardingContentUiState(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -1,5 +1,6 @@
 package com.flint.presentation.onboarding
 
+import android.net.Uri
 import com.flint.core.common.util.UiState
 import com.flint.domain.model.search.SearchContentItemModel
 import com.flint.domain.model.terms.TermModel
@@ -23,6 +24,7 @@ data class OnboardingProfileUiState(
     val isFormatValid: Boolean = true,
     val isNicknameAvailable: Boolean? = null,
     val nicknameErrorType: NicknameErrorType? = null,
+    val profileImageUri: Uri? = null,
 ) {
     companion object {
         const val MAX_LENGTH = 8

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -21,12 +21,14 @@ import com.flint.domain.type.StoragePathType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -251,7 +253,9 @@ class OnboardingViewModel
     private suspend fun uploadProfileImageIfNeeded(): String? {
         val uri = _uiState.value.profileImageUri ?: return null
 
-        val mimeType = context.contentResolver.getType(uri) ?: "image/jpeg"
+        val mimeType = withContext(Dispatchers.IO) {
+            context.contentResolver.getType(uri)
+        } ?: "image/jpeg"
         val extension = mimeTypeToFileExtension(mimeType)
 
         val presignedUrl = storageRepository.getPresignedUrl(
@@ -262,8 +266,9 @@ class OnboardingViewModel
             return null
         }
 
-        val imageBytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-            ?: return null
+        val imageBytes = withContext(Dispatchers.IO) {
+            context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        } ?: return null
 
         storageRepository.uploadToS3(
             uploadUrl = presignedUrl.uploadUrl,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -94,11 +94,7 @@ class OnboardingViewModel
                     isValid = nickname.length >= OnboardingProfileUiState.MIN_LENGTH,
                     isFormatValid = isFormatValid,
                     isNicknameAvailable = null,
-                    nicknameErrorType = when {
-                        !isFormatValid && nickname.isNotEmpty() -> NicknameErrorType.INVALID_FORMAT
-                        currentState.nicknameErrorType == NicknameErrorType.DUPLICATE -> NicknameErrorType.DUPLICATE
-                        else -> null
-                    },
+                    nicknameErrorType = if (!isFormatValid && nickname.isNotEmpty()) NicknameErrorType.INVALID_FORMAT else null,
                 )
             }
         }
@@ -171,7 +167,7 @@ class OnboardingViewModel
         searchJob = viewModelScope.launch {
             _contentUiState.update { it.copy(searchResults = UiState.Loading) }
 
-            val genreApiValue = genre?.let { OnboardingContentUiState.GENRES[it] }
+            val genreApiValue = genre?.let { key -> OnboardingContentUiState.GENRES[key]?.let { listOf(it) } }
 
             searchRepository.getSearchContentList(
                 keyword = keyword,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -1,5 +1,7 @@
 package com.flint.presentation.onboarding
 
+import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -7,29 +9,35 @@ import androidx.navigation.toRoute
 import com.flint.core.common.util.UiState
 import com.flint.core.navigation.Route
 import com.flint.domain.model.auth.SignupRequestModel
+import com.flint.domain.model.search.SearchContentItemModel
 import com.flint.domain.repository.AuthRepository
 import com.flint.domain.repository.SearchRepository
+import com.flint.domain.repository.StorageRepository
 import com.flint.domain.repository.TermsRepository
 import com.flint.domain.repository.UserRepository
+import com.flint.domain.type.FileExtension
 import com.flint.domain.type.OttType
+import com.flint.domain.type.StoragePathType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-import com.flint.domain.model.search.SearchContentItemModel
 
 @HiltViewModel
 class OnboardingViewModel
 @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val userRepository: UserRepository,
     private val searchRepository: SearchRepository,
     private val authRepository: AuthRepository,
+    private val storageRepository: StorageRepository,
     private val termsRepository: TermsRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -126,6 +134,10 @@ class OnboardingViewModel
         }
     }
 
+    fun updateProfileImage(uri: Uri?) {
+        _uiState.update { it.copy(profileImageUri = uri) }
+    }
+
     // ---------- onboarding content ----------
     fun updateSearchKeyword(keyword: String) {
         _contentUiState.update { currentState ->
@@ -218,11 +230,14 @@ class OnboardingViewModel
         viewModelScope.launch {
             _signupUiState.update { it.copy(signupState = UiState.Loading) }
 
+            val profileImageUrl = uploadProfileImageIfNeeded()
+
             val signupRequest = SignupRequestModel(
                 tempToken = tempToken,
                 nickname = _uiState.value.nickname,
                 favoriteContentIds = _contentUiState.value.selectedContents.map { it.id },
                 agreedTermsIds = _termsUiState.value.agreedTermsIds,
+                profileImageUrl = profileImageUrl,
             )
 
             authRepository.signup(signupRequest)
@@ -235,5 +250,41 @@ class OnboardingViewModel
                     Timber.e(error, "Signup failed")
                 }
         }
+    }
+
+    private suspend fun uploadProfileImageIfNeeded(): String? {
+        val uri = _uiState.value.profileImageUri ?: return null
+
+        val mimeType = context.contentResolver.getType(uri) ?: "image/jpeg"
+        val extension = mimeTypeToFileExtension(mimeType)
+
+        val presignedUrl = storageRepository.getPresignedUrl(
+            pathType = StoragePathType.USER_PROFILE,
+            extension = extension,
+        ).getOrElse { error ->
+            Timber.e(error, "Failed to get presigned URL")
+            return null
+        }
+
+        val imageBytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            ?: return null
+
+        storageRepository.uploadToS3(
+            uploadUrl = presignedUrl.uploadUrl,
+            imageBytes = imageBytes,
+            mimeType = mimeType,
+        ).getOrElse { error ->
+            Timber.e(error, "Failed to upload profile image to S3")
+            return null
+        }
+
+        return presignedUrl.key
+    }
+
+    private fun mimeTypeToFileExtension(mimeType: String): FileExtension = when (mimeType) {
+        "image/png" -> FileExtension.PNG
+        "image/gif" -> FileExtension.GIF
+        "image/webp" -> FileExtension.WEBP
+        else -> FileExtension.JPEG
     }
 }

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -58,7 +58,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
             OnboardingTermsRoute(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
-                navigateToOnboardingContent = navController::navigateToOnboardingProfile,
+                navigateToOnboardingProfile = navController::navigateToOnboardingProfile,
                 viewModel = sharedViewModel,
             )
         }

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -27,6 +27,10 @@ fun NavController.navigateToOnboardingTerms() {
     navigate(Route.OnboardingTerms)
 }
 
+fun NavController.navigateToOnboardingProfile() {
+    navigate(Route.OnboardingProfile)
+}
+
 
 fun NavController.navigateToOnboardingContent() {
     navigate(Route.OnboardingContent)
@@ -46,7 +50,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
     navController: NavHostController,
 ) {
     navigation<Route.OnboardingGraph>(
-        startDestination = Route.OnboardingProfile::class,
+        startDestination = Route.OnboardingTerms::class,
     ) {
         composable<Route.OnboardingTerms> { backStackEntry ->
             val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
@@ -54,7 +58,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
             OnboardingTermsRoute(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
-                navigateToOnboardingContent = navController::navigateToOnboardingContent,
+                navigateToOnboardingContent = navController::navigateToOnboardingProfile,
                 viewModel = sharedViewModel,
             )
         }
@@ -65,9 +69,9 @@ fun NavGraphBuilder.onBoardingNavGraph(
             OnboardingProfileRoute(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
-                navigateToOnboardingContent = navController::navigateToOnboardingTerms,
+                navigateToOnboardingContent = navController::navigateToOnboardingContent,
                 viewModel = sharedViewModel,
-                )
+            )
         }
 
         composable<Route.OnboardingContent> { backStackEntry ->

--- a/app/src/main/java/com/flint/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashScreen.kt
@@ -18,7 +18,11 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import com.flint.R
 import com.flint.core.designsystem.theme.FlintTheme
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 
 @Composable
 fun SplashRoute(
@@ -27,12 +31,27 @@ fun SplashRoute(
     navigateToHome: () -> Unit,
     viewModel: SplashViewModel = hiltViewModel(),
 ) {
+    val autoLoginState by viewModel.autoLoginState.collectAsStateWithLifecycle()
+    var isAnimationFinished by remember { mutableStateOf(false) }
+
     SplashScreen(
-        onAnimationFinished = navigateToLogin,
+        onAnimationFinished = { isAnimationFinished = true },
     )
+
+    // 애니메이션이 완료되지 않을 경우를 대비한 fallback
     LaunchedEffect(Unit) {
         delay(2000)
-        navigateToLogin()
+        isAnimationFinished = true
+    }
+
+    LaunchedEffect(isAnimationFinished, autoLoginState) {
+        if (isAnimationFinished && autoLoginState != AutoLoginState.Loading) {
+            when (autoLoginState) {
+                AutoLoginState.NavigateToHome -> navigateToHome()
+                AutoLoginState.NavigateToLogin -> navigateToLogin()
+                AutoLoginState.Loading -> Unit
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
@@ -3,24 +3,39 @@ package com.flint.presentation.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.flint.core.common.util.DataStoreKey.ACCESS_TOKEN
-import com.flint.core.common.util.DataStoreKey.USER_ID
-import com.flint.core.common.util.DataStoreKey.USER_NAME
 import com.flint.data.local.PreferencesManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed interface AutoLoginState {
+    data object Loading : AutoLoginState
+    data object NavigateToHome : AutoLoginState
+    data object NavigateToLogin : AutoLoginState
+}
+
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-        private val preferencesManager: PreferencesManager,
+    private val preferencesManager: PreferencesManager,
 ) : ViewModel() {
+
+    private val _autoLoginState = MutableStateFlow<AutoLoginState>(AutoLoginState.Loading)
+    val autoLoginState: StateFlow<AutoLoginState> = _autoLoginState.asStateFlow()
+
     init {
-//        saveTempUserData()
+        checkAutoLogin()
     }
 
-    fun saveTempUserData() = viewModelScope.launch {
-        preferencesManager.saveString(ACCESS_TOKEN, "eyJhbGciOiJIUzUxMiJ9.eyJ1c2VySWQiOjgwMDAyMTcxMTM1NzExODE5MSwicm9sZSI6IkZMSU5HIiwidHlwZSI6IkFDQ0VTUyIsImlhdCI6MTc2ODgzODU0MCwiZXhwIjoxNzcwMDQ4MTQwfQ.A2XYyu24IoGAXNSQHJ1S-iudWmg8II2_ivI4EdyyWw9KS9oJlxHKOAhcKrsLpLkc9kllZyxwaTJO1t4vI7oZlg")
-        preferencesManager.saveString(USER_ID, "800021711357118191")
-        preferencesManager.saveString(USER_NAME, "hojoo")
+    private fun checkAutoLogin() = viewModelScope.launch {
+        val accessToken = preferencesManager.getString(ACCESS_TOKEN).first()
+        _autoLoginState.value = if (accessToken.isNotEmpty()) {
+            AutoLoginState.NavigateToHome
+        } else {
+            AutoLoginState.NavigateToLogin
+        }
     }
 }

--- a/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/splash/SplashViewModel.kt
@@ -31,10 +31,14 @@ class SplashViewModel @Inject constructor(
     }
 
     private fun checkAutoLogin() = viewModelScope.launch {
-        val accessToken = preferencesManager.getString(ACCESS_TOKEN).first()
-        _autoLoginState.value = if (accessToken.isNotEmpty()) {
-            AutoLoginState.NavigateToHome
-        } else {
+        _autoLoginState.value = try {
+            val accessToken = preferencesManager.getString(ACCESS_TOKEN).first()
+            if (accessToken.isNotEmpty()) {
+                AutoLoginState.NavigateToHome
+            } else {
+                AutoLoginState.NavigateToLogin
+            }
+        } catch (e: Exception) {
             AutoLoginState.NavigateToLogin
         }
     }


### PR DESCRIPTION
## Summary

- 스플래시 화면 자동 로그인 기능 구현
- 프로필 이미지 등록 기능 구현 (Presigned URL → S3 업로드)
- 온보딩 순서 변경: 프로필 설정 → 약관 동의 → **약관 동의 → 프로필 설정**
- 닉네임 입력 UX 개선
  - 자음/모음 단독 입력 시 토스트 없이 확인/다음 버튼 비활성화
  - 한글 자모 중간 입력 허용하도록 정규식 수정
  - 키보드 올라올 때 다음 버튼도 함께 올라오도록 `imePadding` 적용
- 약관 목록 스크롤 추가
- API 스펙 업데이트
  - `SearchApi` genre → `List<String>`, mediaType 추가, cursor 타입 `String?`으로 변경
  - `SearchContentsResponseDto` Meta 필드 추가 (page, size, totalElements, totalPages)
  - `StorageApi` presigned URL 응답에서 `BaseResponse` 래핑 제거
  - S3 `OkHttpClient`에 로깅 인터셉터 추가

## Test plan

- [ ] 스플래시 → 자동 로그인 동작 확인
- [ ] 온보딩 진입 시 약관 동의 화면이 첫 번째로 표시되는지 확인
- [ ] 프로필 이미지 선택 → S3 업로드 → 회원가입 요청에 `profileImageUrl` 포함 확인
- [ ] 닉네임 입력 중 자음/모음만 있을 때 확인/다음 버튼 비활성 및 토스트 미표시 확인
- [ ] 키보드 올라올 때 다음 버튼이 키보드 위로 올라오는지 확인
- [ ] 약관 목록이 많을 때 스크롤 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원가입 중 프로필 이미지 업로드 지원
  * 검색 필터 개선: 장르 다중 선택 및 미디어 타입 필터 추가

* **개선사항**
  * 토스트 메시지가 키보드에 가려지지 않도록 레이아웃 조정
  * 약관 화면 스크롤 기능 추가
  * 온보딩 흐름 및 자동 로그인 프로세스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->