### PR TITLE
[Feature] 자체 qa

### DIFF
--- a/app/src/main/java/com/flint/core/designsystem/component/image/SelectedContentItem.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/image/SelectedContentItem.kt
@@ -1,7 +1,7 @@
 package com.flint.core.designsystem.component.image
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.flint.core.common.extension.noRippleClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -43,7 +43,7 @@ fun SelectedContentItem(
                 Modifier
                     .align(Alignment.TopEnd)
                     .size(48.dp)
-                    .clickable { onRemoveClick() },
+                    .noRippleClickable { onRemoveClick() },
         )
     }
 }

--- a/app/src/main/java/com/flint/core/designsystem/component/listView/SavedContentsSection.kt
+++ b/app/src/main/java/com/flint/core/designsystem/component/listView/SavedContentsSection.kt
@@ -27,6 +27,7 @@ import com.flint.core.designsystem.component.listItem.SavedContentItem
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.content.ContentModel
+import com.flint.domain.type.OttType
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -96,7 +97,6 @@ fun SavedContentsSection(
                 SavedContentItem(
                     contentModel = item,
                     onItemClick = { contentId ->
-
                         onItemClick(contentId)
                     },
                 )

--- a/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailScreen.kt
@@ -41,6 +41,8 @@ import com.flint.domain.model.collection.CollectionDetailModelNew
 import com.flint.domain.model.content.ContentModelNew
 import com.flint.domain.type.UserRoleType
 import com.flint.presentation.collectiondetail.component.CollectionCopyrightFooter
+import com.flint.R
+import com.flint.core.designsystem.component.modal.OneButtonModal
 import com.flint.presentation.collectiondetail.component.CollectionDetailDeleteModal
 import com.flint.presentation.collectiondetail.component.CollectionDetailDescription
 import com.flint.presentation.collectiondetail.component.CollectionDetailThumbnail
@@ -74,6 +76,7 @@ fun CollectionDetailRoute(
     var showContentSaveToast: Boolean by remember { mutableStateOf(false) }
     var showContentCancelToast: Boolean by remember { mutableStateOf(false) }
     var showDeleteModal: Boolean by remember { mutableStateOf(false) }
+    var showBookmarkRestrictionModal: Boolean by remember { mutableStateOf(false) }
     var showEditSuccessToastState: Boolean by remember { mutableStateOf(showEditSuccessToast) }
 
     when (val uiState = uiState) {
@@ -121,6 +124,17 @@ fun CollectionDetailRoute(
         }
 
         else -> {}
+    }
+
+    if (showBookmarkRestrictionModal) {
+        OneButtonModal(
+            title = "작품 저장을 취소할 수 없어요",
+            message = "취향 키워드 분석을 위해\n최소 5개의 작품을 저장해주세요",
+            buttonText = "확인",
+            onConfirm = { showBookmarkRestrictionModal = false },
+            onDismiss = { showBookmarkRestrictionModal = false },
+            icon = R.drawable.ic_gradient_bookmark,
+        )
     }
 
     if (showDeleteModal) {
@@ -216,6 +230,10 @@ fun CollectionDetailRoute(
                         showContentCancelToast = true
                         showContentSaveToast = false
                     }
+                }
+
+                CollectionDetailSideEffect.ToggleContentBookmarkMinLimitExceeded -> {
+                    showBookmarkRestrictionModal = true
                 }
 
                 CollectionDetailSideEffect.DeleteCollectionSuccess -> navigateUpWithDeleteSuccess()

--- a/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/CollectionDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.flint.data.local.PreferencesManager
 import com.flint.domain.model.bookmark.CollectionBookmarkUsersModel
 import com.flint.domain.model.collection.CollectionDetailModelNew
 import com.flint.domain.model.content.ContentModelNew
+import com.flint.domain.model.bookmark.BookmarkException
 import com.flint.domain.repository.BookmarkRepository
 import com.flint.domain.repository.CollectionRepository
 import com.flint.presentation.collectiondetail.sideeffect.CollectionDetailSideEffect
@@ -107,14 +108,47 @@ class CollectionDetailViewModel @Inject constructor(
 
         val newBookmarkState: Boolean = !targetContent.isBookmarked
         val initialBookmarkCount: Int = targetContent.bookmarkCount
-        val adjustedBookmarkCount: Int =
-            if (newBookmarkState) initialBookmarkCount + 1
-            else (initialBookmarkCount - 1).coerceAtLeast(0)
 
+        // 북마크 취소
+        if (!newBookmarkState) {
+            contentBookmarkDebounceJobs[contentId]?.cancel()
+            contentBookmarkDebounceJobs.remove(contentId)
+            val initialState = initialContentBookmarkStates.remove(contentId)
+
+            if (initialState == false) {
+                updateContentBookmarkState(
+                    contentId = contentId,
+                    isBookmarked = false,
+                    bookmarkCount = (initialBookmarkCount - 1).coerceAtLeast(0),
+                )
+                return
+            }
+
+            viewModelScope.launch {
+                bookmarkRepository.toggleContentBookmark(contentId)
+                    .onSuccess { isBookmarked: Boolean ->
+                        updateContentBookmarkState(
+                            contentId = contentId,
+                            isBookmarked = isBookmarked,
+                            bookmarkCount = (initialBookmarkCount - 1).coerceAtLeast(0),
+                        )
+                        _sideEffect.emit(CollectionDetailSideEffect.ToggleContentBookmarkSuccess(isBookmarked))
+                    }
+                    .onFailure { throwable ->
+                        if (throwable is BookmarkException.ContentMinLimitExceeded) {
+                            _sideEffect.emit(CollectionDetailSideEffect.ToggleContentBookmarkMinLimitExceeded)
+                        }
+                    }
+            }
+            return
+        }
+
+        // 북마크 추가
+        val adjustedBookmarkCount: Int = initialBookmarkCount + 1
         updateContentBookmarkState(
             contentId = contentId,
             isBookmarked = newBookmarkState,
-            bookmarkCount = adjustedBookmarkCount
+            bookmarkCount = adjustedBookmarkCount,
         )
 
         contentBookmarkDebounceJobs[contentId]?.cancel()
@@ -132,7 +166,7 @@ class CollectionDetailViewModel @Inject constructor(
                     .onSuccess { isBookmarked: Boolean ->
                         updateContentIsBookmarkedOnly(
                             contentId = contentId,
-                            isBookmarked = isBookmarked
+                            isBookmarked = isBookmarked,
                         )
                         _sideEffect.emit(
                             CollectionDetailSideEffect.ToggleContentBookmarkSuccess(isBookmarked)
@@ -143,14 +177,10 @@ class CollectionDetailViewModel @Inject constructor(
                             (_uiState.value as? UiState.Success)?.data?.collectionDetail?.contents
                                 ?.find { it.id == contentId } ?: return@onFailure
 
-                        val rollbackCount: Int =
-                            if (initialState) fallbackContent.bookmarkCount + 1
-                            else (fallbackContent.bookmarkCount - 1).coerceAtLeast(0)
-
                         updateContentBookmarkState(
                             contentId = contentId,
                             isBookmarked = initialState,
-                            bookmarkCount = rollbackCount
+                            bookmarkCount = (fallbackContent.bookmarkCount - 1).coerceAtLeast(0),
                         )
                     }
             }

--- a/app/src/main/java/com/flint/presentation/collectiondetail/sideeffect/CollectionDetailSideEffect.kt
+++ b/app/src/main/java/com/flint/presentation/collectiondetail/sideeffect/CollectionDetailSideEffect.kt
@@ -7,6 +7,8 @@ sealed interface CollectionDetailSideEffect {
 
     class ToggleContentBookmarkSuccess(val isBookmarked: Boolean) : CollectionDetailSideEffect
 
+    object ToggleContentBookmarkMinLimitExceeded : CollectionDetailSideEffect
+
     object DeleteCollectionSuccess : CollectionDetailSideEffect
 
     object DeleteCollectionFailure : CollectionDetailSideEffect

--- a/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/flint/presentation/main/MainNavHost.kt
@@ -22,6 +22,8 @@ import com.flint.presentation.explore.navigation.exploreNavGraph
 import com.flint.presentation.home.navigation.homeNavGraph
 import com.flint.presentation.login.navigation.loginNavGraph
 import com.flint.presentation.onboarding.navigation.onBoardingNavGraph
+import com.flint.core.navigation.MainTabRoute
+import com.flint.presentation.profile.navigation.KEY_PROFILE_UPDATED
 import com.flint.presentation.profile.navigation.myProfileNavGraph
 import com.flint.presentation.profile.navigation.profileNavGraph
 import com.flint.presentation.savedcontent.navigation.savedContentListNavGraph
@@ -144,6 +146,15 @@ fun MainNavHost(
 
             editProfileNavGraph(
                 navigateUp = navigator::navigateUp,
+                onProfileSaved = {
+                    try {
+                        navigator.navController
+                            .getBackStackEntry(MainTabRoute.Profile)
+                            .savedStateHandle[KEY_PROFILE_UPDATED] = true
+                    } catch (_: IllegalArgumentException) {
+                        // MainTabRoute.Profile이 백스택에 없는 경우 무시
+                    }
+                },
             )
 
             withdrawNavGraph(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -158,7 +158,7 @@ fun OnboardingContentScreen(
                         },
                     )
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(24.dp))
                 }
             }
 
@@ -203,6 +203,8 @@ fun OnboardingContentScreen(
                                 )
                             }
                         }
+
+                        Spacer(modifier = Modifier.height(8.dp))
 
                         FlintSearchTextField(
                             placeholder = "작품 이름",
@@ -307,7 +309,7 @@ fun OnboardingContentScreen(
                                 contentAlignment = Alignment.Center,
                             ) {
                                 FlintSearchEmptyView(
-                                    title = "작품을 찾을 수 없어요"
+                                    title = "아직 준비 중인 작품이에요"
                                 )
                             }
                         }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -141,10 +141,21 @@ fun OnboardingContentScreen(
             // 타이틀 영역 - 스크롤됨
             item(span = { GridItemSpan(3) }) {
                 Column {
+                    var useMultiLine by remember(nickname) { mutableStateOf(false) }
                     Text(
-                        text = "${nickname}님이 좋아하는 작품\n7개를 골라주세요",
+                        text = if (useMultiLine) {
+                            "${nickname}님이\n좋아하는 작품\n7개를 골라주세요"
+                        } else {
+                            "${nickname}님이 좋아하는 작품\n7개를 골라주세요"
+                        },
                         color = FlintTheme.colors.white,
                         style = FlintTheme.typography.display2M28,
+                        onTextLayout = { result ->
+                            // 2줄 포맷인데 실제 렌더링이 3줄 이상이면 자연 줄바꿈 발생한 것
+                            if (!useMultiLine && result.lineCount > 2) {
+                                useMultiLine = true
+                            }
+                        },
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -290,7 +290,7 @@ fun OnboardingContentScreen(
                             contentAlignment = Alignment.Center,
                         ) {
                             FlintSearchEmptyView(
-                                title = "아직 준비 중인 작품이이요"
+                                title = "아직 준비 중인 작품이에요"
                             )
                         }
                     }

--- a/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
@@ -48,6 +48,7 @@ import com.flint.core.navigation.model.CollectionListRouteType
 import com.flint.domain.model.collection.CollectionListModel
 import com.flint.domain.model.content.BookmarkedContentListModel
 import com.flint.domain.model.ott.OttListModel
+import com.flint.domain.model.ott.OttModel
 import com.flint.domain.model.user.KeywordListModel
 import com.flint.domain.model.user.UserProfileResponseModel
 import com.flint.presentation.MainActivity
@@ -104,7 +105,11 @@ fun ProfileRoute(
         onCollectionItemClick = navigateToCollectionDetail,
         onSettingsClick = navigateToSetting,
         onContentItemClick = { contentId ->
-            viewModel.getOttListPerContent(contentId)
+            val ottList = (uiState.sectionData as? UiState.Success)
+                ?.data?.savedContents?.contents
+                ?.find { it.id == contentId }?.getOttSimpleList ?: emptyList()
+            ottListModel = OttListModel(otts = ottList.map { OttModel(name = it.name) })
+            if (ottListModel.otts.isNotEmpty()) showOttListBottomSheet = true
         },
         onContentMoreClick = { navigateToSavedContentList(uiState.userId) },
         onCreatedCollectionMoreClick = {

--- a/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
@@ -67,6 +67,8 @@ fun ProfileRoute(
     navigateToSavedContentList: (userId: String?) -> Unit,
     navigateToCollectionDetail: (collectionId: String) -> Unit,
     navigateToSetting: () -> Unit = {},
+    shouldRefreshProfile: Boolean = false,
+    onProfileRefreshed: () -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -76,6 +78,13 @@ fun ProfileRoute(
     var showOttListBottomSheet by remember { mutableStateOf(false) }
     var ottListModel by remember { mutableStateOf(OttListModel()) }
     val sheetState = rememberModalBottomSheetState()
+
+    LaunchedEffect(shouldRefreshProfile) {
+        if (shouldRefreshProfile) {
+            viewModel.reloadUserProfile()
+            onProfileRefreshed()
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -149,6 +149,17 @@ class ProfileViewModel @Inject constructor(
             }
     }
 
+    // 프로필 헤더만 재조회 (섹션 데이터는 유지)
+    fun reloadUserProfile() {
+        viewModelScope.launch {
+            userRepository.getUserProfile(userId = userId)
+                .onSuccess { profile ->
+                    _uiState.update { it.copy(profile = profile) }
+                }
+                .onFailure { Timber.e(it) }
+        }
+    }
+
     fun recalculateKeywords() = viewModelScope.launch {
         _uiState.update { it.copy(isRecalculating = true) }
         userRepository.recalculateKeywords()

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentScreen.kt
@@ -12,9 +12,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -25,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flint.R
 import com.flint.core.common.util.UiState
+import com.flint.core.designsystem.component.bottomsheet.OttListBottomSheet
 import com.flint.core.designsystem.component.indicator.FlintLoadingIndicator
 import com.flint.core.designsystem.component.modal.OneButtonModal
 import com.flint.core.designsystem.component.textfield.FlintSearchTextField
@@ -33,6 +38,8 @@ import com.flint.core.designsystem.component.view.FlintSearchEmptyView
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.content.BookmarkedContentItemModel
 import com.flint.domain.model.content.BookmarkedContentListModel
+import com.flint.domain.model.ott.OttListModel
+import com.flint.domain.model.ott.OttModel
 import com.flint.domain.type.OttType
 import com.flint.presentation.profile.component.CollectionCreateContentBookmark
 import com.flint.presentation.profile.uistate.SavedContentUiState
@@ -58,6 +65,7 @@ fun SavedContentRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SavedContentScreen(
     uiState: SavedContentUiState,
@@ -69,6 +77,8 @@ fun SavedContentScreen(
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    var showOttBottomSheet by remember { mutableStateOf(false) }
+    var selectedOttList by remember { mutableStateOf<List<OttType>>(emptyList()) }
 
     Column(
         modifier = modifier
@@ -134,6 +144,10 @@ fun SavedContentScreen(
                     SavedContentList(
                         contents = uiState.filteredContents,
                         onBookmarkClick = onBookmarkClick,
+                        onMoreClick = { ottList ->
+                            selectedOttList = ottList
+                            showOttBottomSheet = true
+                        },
                     )
                 }
             }
@@ -149,6 +163,13 @@ fun SavedContentScreen(
                 }
             }
         }
+    }
+
+    if (showOttBottomSheet && selectedOttList.isNotEmpty()) {
+        OttListBottomSheet(
+            ottList = OttListModel(otts = selectedOttList.map { OttModel(name = it.name) }),
+            onDismiss = { showOttBottomSheet = false },
+        )
     }
 
     // 저장 취소 제한 안내 모달 (저장 작품이 5개일 때 북마크 토글 시 노출)
@@ -168,6 +189,7 @@ fun SavedContentScreen(
 private fun SavedContentList(
     contents: ImmutableList<BookmarkedContentItemModel>,
     onBookmarkClick: (contentId: String) -> Unit,
+    onMoreClick: (ottList: List<OttType>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (contents.isEmpty()) {
@@ -192,7 +214,7 @@ private fun SavedContentList(
             CollectionCreateContentBookmark(
                 modifier = Modifier.animateItem(),
                 onBookmarkClick = { onBookmarkClick(content.id) },
-                onMoreClick = {},
+                onMoreClick = { onMoreClick(content.getOttSimpleList) },
                 isBookmarked = content.isBookmarked,
                 bookmarkCount = content.bookmarkCount,
                 imageUrl = content.imageUrl,

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentScreen.kt
@@ -146,12 +146,12 @@ fun SavedContentScreen(
             onClearAction = onClearSearch,
         )
 
-        // "총 n개"는 실제 데이터가 있는 Success 상태에서만 노출
-        if (uiState.contents is UiState.Success) {
+        // "총 n개"는 검색 결과가 있을 때만 노출
+        if (uiState.contents is UiState.Success && uiState.filteredContents.isNotEmpty()) {
             Spacer(modifier = Modifier.height(16.dp))
 
             Text(
-                text = "총 ${uiState.totalCount}개",
+                text = "총 ${uiState.filteredContents.size}개",
                 modifier = Modifier.padding(horizontal = 16.dp),
                 color = FlintTheme.colors.gray100,
                 style = FlintTheme.typography.body2R14,

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +33,7 @@ import com.flint.core.common.util.UiState
 import com.flint.core.designsystem.component.bottomsheet.OttListBottomSheet
 import com.flint.core.designsystem.component.indicator.FlintLoadingIndicator
 import com.flint.core.designsystem.component.modal.OneButtonModal
+import com.flint.core.designsystem.component.toast.ShowToast
 import com.flint.core.designsystem.component.textfield.FlintSearchTextField
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.component.view.FlintSearchEmptyView
@@ -53,6 +55,24 @@ fun SavedContentRoute(
     viewModel: SavedContentViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showSaveToast by remember { mutableStateOf(false) }
+    var showCancelToast by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is SavedContentSideEffect.ToggleBookmarkSuccess -> {
+                    if (effect.isBookmarked) {
+                        showSaveToast = true
+                        showCancelToast = false
+                    } else {
+                        showCancelToast = true
+                        showSaveToast = false
+                    }
+                }
+            }
+        }
+    }
 
     SavedContentScreen(
         uiState = uiState,
@@ -63,6 +83,26 @@ fun SavedContentRoute(
         onDismissRestrictionModal = viewModel::dismissBookmarkRestrictionModal,
         modifier = Modifier.padding(paddingValues),
     )
+
+    if (showSaveToast) {
+        ShowToast(
+            text = "작품을 저장했어요",
+            imageVector = null,
+            paddingValues = paddingValues,
+            yOffset = 12.dp,
+            hide = { showSaveToast = false },
+        )
+    }
+
+    if (showCancelToast) {
+        ShowToast(
+            text = "작품 저장이 취소되었어요",
+            imageVector = null,
+            paddingValues = paddingValues,
+            yOffset = 12.dp,
+            hide = { showCancelToast = false },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentSideEffect.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentSideEffect.kt
@@ -1,0 +1,5 @@
+package com.flint.presentation.profile
+
+sealed interface SavedContentSideEffect {
+    data class ToggleBookmarkSuccess(val isBookmarked: Boolean) : SavedContentSideEffect
+}

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentViewModel.kt
@@ -87,6 +87,7 @@ class SavedContentViewModel @Inject constructor(
                         val currentList = (state.contents as? UiState.Success)?.data
                             ?: return@update state
                         val updated = currentList.copy(
+                            totalCount = currentList.totalCount + if (isBookmarked) 1 else -1,
                             contents = currentList.contents
                                 .map { if (it.id == contentId) it.copy(isBookmarked = isBookmarked) else it }
                                 .toPersistentList()

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentViewModel.kt
@@ -12,8 +12,11 @@ import com.flint.domain.repository.UserRepository
 import com.flint.presentation.profile.uistate.SavedContentUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -31,6 +34,9 @@ class SavedContentViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(SavedContentUiState())
     val uiState: StateFlow<SavedContentUiState> = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<SavedContentSideEffect>()
+    val sideEffect: SharedFlow<SavedContentSideEffect> = _sideEffect.asSharedFlow()
 
     init {
         loadBookmarkedContents()
@@ -94,6 +100,7 @@ class SavedContentViewModel @Inject constructor(
                         )
                         state.copy(contents = UiState.Success(updated))
                     }
+                    _sideEffect.emit(SavedContentSideEffect.ToggleBookmarkSuccess(isBookmarked))
                 }
                 .onFailure { throwable ->
                     if (throwable is BookmarkException.ContentMinLimitExceeded) {

--- a/app/src/main/java/com/flint/presentation/profile/SavedContentViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/SavedContentViewModel.kt
@@ -93,7 +93,7 @@ class SavedContentViewModel @Inject constructor(
                         val currentList = (state.contents as? UiState.Success)?.data
                             ?: return@update state
                         val updated = currentList.copy(
-                            totalCount = currentList.totalCount + if (isBookmarked) 1 else -1,
+                            totalCount = maxOf(0, currentList.totalCount + if (isBookmarked) 1 else -1),
                             contents = currentList.contents
                                 .map { if (it.id == contentId) it.copy(isBookmarked = isBookmarked) else it }
                                 .toPersistentList()

--- a/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/profile/navigation/ProfileNavigation.kt
@@ -1,6 +1,8 @@
 package com.flint.presentation.profile.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -9,6 +11,8 @@ import com.flint.core.navigation.MainTabRoute
 import com.flint.core.navigation.Route
 import com.flint.core.navigation.model.CollectionListRouteType
 import com.flint.presentation.profile.ProfileRoute
+
+const val KEY_PROFILE_UPDATED = "key_profile_updated"
 
 fun NavController.navigateToMyProfile(
     navOptions: NavOptions? = null
@@ -30,7 +34,11 @@ fun NavGraphBuilder.myProfileNavGraph(
     navigateToCollectionDetail: (collectionId: String) -> Unit,
     navigateToSetting: () -> Unit = {},
 ) {
-    composable<MainTabRoute.Profile> {
+    composable<MainTabRoute.Profile> { entry ->
+        val shouldRefreshProfile by entry.savedStateHandle
+            .getStateFlow(KEY_PROFILE_UPDATED, false)
+            .collectAsStateWithLifecycle()
+
         ProfileRoute(
             paddingValues = paddingValues,
             navigateUp = {},
@@ -38,6 +46,10 @@ fun NavGraphBuilder.myProfileNavGraph(
             navigateToSavedContentList = navigateToSavedContentList,
             navigateToCollectionDetail = navigateToCollectionDetail,
             navigateToSetting = navigateToSetting,
+            shouldRefreshProfile = shouldRefreshProfile,
+            onProfileRefreshed = {
+                entry.savedStateHandle[KEY_PROFILE_UPDATED] = false
+            },
         )
     }
 }

--- a/app/src/main/java/com/flint/presentation/setting/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/setting/editprofile/EditProfileScreen.kt
@@ -54,6 +54,7 @@ import com.flint.core.designsystem.theme.FlintTheme
 @Composable
 fun EditProfileRoute(
     navigateUp: () -> Unit,
+    onProfileSaved: () -> Unit = {},
     viewModel: EditProfileViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -63,7 +64,10 @@ fun EditProfileRoute(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.navigateUp.collect { navigateUp() }
+        viewModel.navigateUp.collect {
+            onProfileSaved()
+            navigateUp()
+        }
     }
 
     EditProfileScreen(

--- a/app/src/main/java/com/flint/presentation/setting/editprofile/navigation/EditProfileNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/setting/editprofile/navigation/EditProfileNavigation.kt
@@ -13,10 +13,12 @@ fun NavController.navigateToEditProfile(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.editProfileNavGraph(
     navigateUp: () -> Unit,
+    onProfileSaved: () -> Unit = {},
 ) {
     composable<Route.EditProfile> {
         EditProfileRoute(
             navigateUp = navigateUp,
+            onProfileSaved = onProfileSaved,
         )
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- [ ] 저장한 작품 화면에서 북마크 토글 시 총 개수 즉시 반영
- [ ] 저장한 작품 5개 이하 상태에서 북마크 취소 시 모달 정상 노출 
- [ ] 컬렉션 상세에서 북마크 취소 시 플리커 없이 모달만 노출
- [ ] 저장한 작품 아이템 / OTT 버튼 클릭 시 바텀시트 정상 노출 -> api 없이 ottLists 사용
- [ ] My 프로필 저장한 작품 섹션 아이템 클릭 시 바텀시트 정상 노출
- [ ] 북마크 저장/취소 시 토스트 정상 노출
- [ ] 프로필 수정 저장 후 My 화면 복귀 시 닉네임/이미지 자동 갱신




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 콘텐츠 북마크 토글 시 “최소 제한 초과” 안내 모달 표시
  * 프로필 편집 후 프로필 탭 진입 시 헤더 정보 자동 새로고침
  * 저장된 콘텐츠 화면에서 북마크 토글 성공/취소 토스트 표시
  * 저장 화면에서 OTT 목록 바텀시트 및 더보기 동작 개선
* **버그 수정**
  * 북마크 토글 실패 시 롤백 및 북마크 수 산정 로직 개선
* **UI 개선**
  * 온보딩 타이틀/간격, 검색 빈 화면 문구 수정 및 제거 아이콘 리플 처리 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->