### PR TITLE
[Feat] 1차 QA  수정사항 반영

### DIFF
--- a/app/src/main/java/com/flint/core/common/extension/StringExt.kt
+++ b/app/src/main/java/com/flint/core/common/extension/StringExt.kt
@@ -1,0 +1,13 @@
+package com.flint.core.common.extension
+
+private const val ZERO_WIDTH_SPACE = '​'
+private val HANGUL_SYLLABLE_RANGE = 0xAC00..0xD7A3
+
+// 한글 음절 사이에 zero-width space(U+200B)를 삽입해 줄바꿈 기회를 추가
+// → 공간이 남아있으면 단어 경계가 아닌 글자 경계에서 줄바꿈 가능
+fun String.addKoreanLineBreaks(): String = buildString {
+    for (char in this@addKoreanLineBreaks) {
+        append(char)
+        if (char.code in HANGUL_SYLLABLE_RANGE) append(ZERO_WIDTH_SPACE)
+    }
+}

--- a/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
@@ -66,7 +66,7 @@ fun CollectionFileItem(
                 .padding(horizontal = 8.dp),
         ) {
             Text(
-                text = collection.title,
+                text = collection.title.addKoreanLineBreaks(),
                 style = FlintTheme.typography.body1M16,
                 color = FlintTheme.colors.white,
                 maxLines = 2,
@@ -74,7 +74,7 @@ fun CollectionFileItem(
             )
 
             Text(
-                text = collection.description,
+                text = collection.description.addKoreanLineBreaks(),
                 style = FlintTheme.typography.caption1R12,
                 color = FlintTheme.colors.gray300,
                 maxLines = 2,
@@ -206,6 +206,13 @@ private fun CollectionPocketPoster(
             .size(width = 80.dp, height = 120.dp)
             .clip(RoundedCornerShape(12.dp)),
     )
+}
+
+private fun String.addKoreanLineBreaks(): String = buildString {
+    for (char in this@addKoreanLineBreaks) {
+        append(char)
+        if (char.code in 0xAC00..0xD7A3) append('​')
+    }
 }
 
 @Preview(showBackground = false)

--- a/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
+++ b/app/src/main/java/com/flint/presentation/collectionlist/component/CollectionFileItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.flint.R
+import com.flint.core.common.extension.addKoreanLineBreaks
 import com.flint.core.common.extension.dropShadow
 import com.flint.core.common.extension.noRippleClickable
 import com.flint.core.designsystem.component.image.NetworkImage
@@ -42,6 +44,9 @@ fun CollectionFileItem(
     onBookmarkClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val displayTitle = remember(collection.title) { collection.title.addKoreanLineBreaks() }
+    val displayDescription = remember(collection.description) { collection.description.addKoreanLineBreaks() }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier,
@@ -66,7 +71,7 @@ fun CollectionFileItem(
                 .padding(horizontal = 8.dp),
         ) {
             Text(
-                text = collection.title.addKoreanLineBreaks(),
+                text = displayTitle,
                 style = FlintTheme.typography.body1M16,
                 color = FlintTheme.colors.white,
                 maxLines = 2,
@@ -74,7 +79,7 @@ fun CollectionFileItem(
             )
 
             Text(
-                text = collection.description.addKoreanLineBreaks(),
+                text = displayDescription,
                 style = FlintTheme.typography.caption1R12,
                 color = FlintTheme.colors.gray300,
                 maxLines = 2,
@@ -206,13 +211,6 @@ private fun CollectionPocketPoster(
             .size(width = 80.dp, height = 120.dp)
             .clip(RoundedCornerShape(12.dp)),
     )
-}
-
-private fun String.addKoreanLineBreaks(): String = buildString {
-    for (char in this@addKoreanLineBreaks) {
-        append(char)
-        if (char.code in 0xAC00..0xD7A3) append('​')
-    }
 }
 
 @Preview(showBackground = false)

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -49,6 +49,7 @@ import com.flint.core.designsystem.component.button.FlintLargeButton
 import com.flint.core.designsystem.component.image.SelectedContentItem
 import com.flint.core.designsystem.component.textfield.FlintSearchTextField
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
+import com.flint.core.designsystem.component.indicator.FlintLoadingIndicator
 import com.flint.core.designsystem.component.view.FlintSearchEmptyView
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.search.SearchContentItemModel
@@ -296,7 +297,16 @@ fun OnboardingContentScreen(
                     }
                 }
                 is UiState.Loading -> {
-                    // 로딩
+                    item(span = { GridItemSpan(3) }) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(300.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            FlintLoadingIndicator()
+                        }
+                    }
                 }
                 is UiState.Success -> {
                     if (searchResultsState.data.isEmpty()) {

--- a/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingContentItem.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingContentItem.kt
@@ -85,7 +85,7 @@ fun OnboardingContentItem(
 
         // 영화 제목
         Text(
-            text = title,
+            text = title.addKoreanLineBreaks(),
             style = FlintTheme.typography.body1R16,
             color = FlintTheme.colors.white,
             maxLines = 2,
@@ -112,6 +112,15 @@ fun OnboardingContentItem(
             maxLines = 1,
             modifier = Modifier.fillMaxWidth(),
         )
+    }
+}
+
+// 한글 음절 사이에 zero-width space(U+200B)를 삽입해 줄바꿈 기회를 추가
+// → 공간이 남아있으면 단어 경계가 아닌 글자 경계에서 줄바꿈 가능
+private fun String.addKoreanLineBreaks(): String = buildString {
+    for (char in this@addKoreanLineBreaks) {
+        append(char)
+        if (char.code in 0xAC00..0xD7A3) append('​')
     }
 }
 

--- a/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingContentItem.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/component/OnboardingContentItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,6 +27,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.flint.R
+import com.flint.core.common.extension.addKoreanLineBreaks
 import com.flint.core.designsystem.component.image.NetworkImage
 import com.flint.core.designsystem.theme.FlintColors
 import com.flint.core.designsystem.theme.FlintTheme
@@ -40,6 +42,8 @@ fun OnboardingContentItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val displayTitle = remember(title) { title.addKoreanLineBreaks() }
+
     Column(
         modifier = modifier.width(100.dp),
         horizontalAlignment = Alignment.Start,
@@ -85,7 +89,7 @@ fun OnboardingContentItem(
 
         // 영화 제목
         Text(
-            text = title.addKoreanLineBreaks(),
+            text = displayTitle,
             style = FlintTheme.typography.body1R16,
             color = FlintTheme.colors.white,
             maxLines = 2,
@@ -112,15 +116,6 @@ fun OnboardingContentItem(
             maxLines = 1,
             modifier = Modifier.fillMaxWidth(),
         )
-    }
-}
-
-// 한글 음절 사이에 zero-width space(U+200B)를 삽입해 줄바꿈 기회를 추가
-// → 공간이 남아있으면 단어 경계가 아닌 글자 경계에서 줄바꿈 가능
-private fun String.addKoreanLineBreaks(): String = buildString {
-    for (char in this@addKoreanLineBreaks) {
-        append(char)
-        if (char.code in 0xAC00..0xD7A3) append('​')
     }
 }
 

--- a/app/src/main/java/com/flint/presentation/profile/component/ProfileKeywordSection.kt
+++ b/app/src/main/java/com/flint/presentation/profile/component/ProfileKeywordSection.kt
@@ -110,7 +110,7 @@ fun ProfileKeywordSection(
             )
             if (isMyProfile && showInfoModal) {
                 InfoModalTrigger(
-                    text = "저장한 작품들에서 반복되는 키워드를 분석해 취향 키워드를 만들어요. 10개 이상 작품이 쌓이면 업데이트할 수 있어요.",
+                    text = "저장한 작품들에서 반복되는 키워드를 분석해 취향 키워드를 만들어요. 20개 이상 작품이 쌓이면 업데이트할 수 있어요.",
                     modifier = Modifier
                         .fillMaxWidth()
                         .offset(y = (-20).dp),


### PR DESCRIPTION
## 📮 관련 이슈
- closed #이슈번호

## 📌 작업 내용
- 온보딩 콘텐츠 검색 화면 로딩 인디케이터 추가 (초기 진입 및 장르 칩 선택 시)
- 컬렉션 리스트 아이템 제목/설명 한글 줄바꿈 개선 (zero-width space 삽입)
- 온보딩 콘텐츠 아이템 제목 한글 줄바꿈 개선
- 취향 키워드 업데이트 기준 텍스트 수정 (10개 → 20개)


## 😅 미구현ㅂ- [ ] 온보딩 done 회원 정보 저장 

## 🫛 To. 리뷰어
- 온보딩 done 회원 정보 저장은 추가 논의가 필요해 남겨뒀습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 한글 제목과 설명이 화면 너비에 맞춰 더 자연스럽게 줄바꿈됩니다.
  * 온보딩 콘텐츠 목록을 불러오는 동안 전체 폭 로딩 인디케이터가 표시됩니다.

* **버그 수정**
  * 긴 한글 문구의 표시와 줄바꿈 처리가 개선되었습니다.
  * 프로필 안내 문구의 업데이트 가능 기준이 저장 작품 20개 이상으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->