### PR TITLE
[FIX]  1차 QA 수정사항 반영 (온보딩/프로필)

### DIFF
--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -135,22 +135,11 @@ fun OnboardingContentScreen(
         ) {
             // 타이틀 영역 - 스크롤됨
             item(span = { GridItemSpan(3) }) {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    var isSingleLine by remember { mutableStateOf(true) }
+                Column {
                     Text(
-                        text = if (isSingleLine) {
-                            "좋아하는 작품 7개를 골라주세요"
-                        } else {
-                            "좋아하는 작품\n7개를 골라주세요"
-                        },
+                        text = "내 취향에 가까운 작품\n7개를 골라주세요",
                         color = FlintTheme.colors.white,
                         style = FlintTheme.typography.display2M28,
-                        onTextLayout = { result ->
-                            // 좌우 16dp 패딩 안에서 한 줄로 안 들어가면(자연 줄바꿈 발생) 수동 줄바꿈으로 전환
-                            if (isSingleLine && result.lineCount > 1) {
-                                isSingleLine = false
-                            }
-                        },
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -137,7 +137,8 @@ fun OnboardingContentScreen(
             item(span = { GridItemSpan(3) }) {
                 Column {
                     Text(
-                        text = "내 취향에 가까운 작품\n7개를 골라주세요",
+                        text = "내 취향에 가까운 작품 7개를 골라주세요",
+                        maxLines = 2,
                         color = FlintTheme.colors.white,
                         style = FlintTheme.typography.display2M28,
                     )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -137,8 +137,7 @@ fun OnboardingContentScreen(
             item(span = { GridItemSpan(3) }) {
                 Column {
                     Text(
-                        text = "내 취향에 가까운 작품 7개를 골라주세요",
-                        maxLines = 2,
+                        text = "내 취향에 가까운 작품\n7개를 골라주세요",
                         color = FlintTheme.colors.white,
                         style = FlintTheme.typography.display2M28,
                     )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -135,11 +135,22 @@ fun OnboardingContentScreen(
         ) {
             // 타이틀 영역 - 스크롤됨
             item(span = { GridItemSpan(3) }) {
-                Column {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    var isSingleLine by remember { mutableStateOf(true) }
                     Text(
-                        text = "좋아하는 작품 7개를\n골라주세요",
+                        text = if (isSingleLine) {
+                            "좋아하는 작품 7개를 골라주세요"
+                        } else {
+                            "좋아하는 작품\n7개를 골라주세요"
+                        },
                         color = FlintTheme.colors.white,
                         style = FlintTheme.typography.display2M28,
+                        onTextLayout = { result ->
+                            // 좌우 16dp 패딩 안에서 한 줄로 안 들어가면(자연 줄바꿈 발생) 수동 줄바꿈으로 전환
+                            if (isSingleLine && result.lineCount > 1) {
+                                isSingleLine = false
+                            }
+                        },
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingContentScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -41,15 +40,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.flint.core.common.extension.dropShadow
 import com.flint.core.common.util.UiState
-import com.flint.core.designsystem.component.button.FlintBasicButton
 import com.flint.core.designsystem.component.button.FlintButtonState
 import com.flint.core.designsystem.component.button.FlintLargeButton
 import com.flint.core.designsystem.component.image.SelectedContentItem
 import com.flint.core.designsystem.component.textfield.FlintSearchTextField
-import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.component.indicator.FlintLoadingIndicator
+import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.component.view.FlintSearchEmptyView
 import com.flint.core.designsystem.theme.FlintTheme
 import com.flint.domain.model.search.SearchContentItemModel
@@ -61,11 +58,10 @@ import com.flint.presentation.onboarding.component.StepProgressBar
 @Composable
 fun OnboardingContentRoute(
     paddingValues: PaddingValues,
-    navigateToOnboardingDone: () -> Unit,
+    navigateToOnboardingProfile: () -> Unit,
     navigateUp: () -> Unit,
     viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
-    val profileUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val contentUiState by viewModel.contentUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
@@ -73,10 +69,9 @@ fun OnboardingContentRoute(
     }
 
     OnboardingContentScreen(
-        nickname = profileUiState.nickname,
         contentUiState = contentUiState,
         onBackClick = navigateUp,
-        onNextClick = navigateToOnboardingDone,
+        onNextClick = navigateToOnboardingProfile,
         onSearchKeywordChanged = viewModel::updateSearchKeyword,
         onSearchAction = viewModel::searchContents,
         onClearAction = viewModel::clearSearchKeyword,
@@ -90,7 +85,6 @@ fun OnboardingContentRoute(
 
 @Composable
 fun OnboardingContentScreen(
-    nickname: String,
     contentUiState: OnboardingContentUiState,
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
@@ -142,21 +136,10 @@ fun OnboardingContentScreen(
             // 타이틀 영역 - 스크롤됨
             item(span = { GridItemSpan(3) }) {
                 Column {
-                    var useMultiLine by remember(nickname) { mutableStateOf(false) }
                     Text(
-                        text = if (useMultiLine) {
-                            "${nickname}님이\n좋아하는 작품\n7개를 골라주세요"
-                        } else {
-                            "${nickname}님이 좋아하는 작품\n7개를 골라주세요"
-                        },
+                        text = "좋아하는 작품 7개를\n골라주세요",
                         color = FlintTheme.colors.white,
                         style = FlintTheme.typography.display2M28,
-                        onTextLayout = { result ->
-                            // 2줄 포맷인데 실제 렌더링이 3줄 이상이면 자연 줄바꿈 발생한 것
-                            if (!useMultiLine && result.lineCount > 2) {
-                                useMultiLine = true
-                            }
-                        },
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))
@@ -349,13 +332,12 @@ fun OnboardingContentScreen(
         FlintLargeButton(
             text = "다음",
             state = if (contentUiState.canProceed) FlintButtonState.Able else FlintButtonState.Disable,
-            onClick = { if (contentUiState.canProceed) { onNextClick() } },
+            onClick = { if (contentUiState.canProceed) onNextClick() },
             enabled = contentUiState.canProceed,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 20.dp),
-
-            )
+        )
     }
 }
 
@@ -364,7 +346,6 @@ fun OnboardingContentScreen(
 private fun OnboardingContentScreenListPreview() {
     FlintTheme {
         OnboardingContentScreen(
-            nickname = "안비",
             contentUiState = OnboardingContentUiState(
                 searchResults = UiState.Success(
                     SearchContentListModel.FakeList
@@ -389,7 +370,6 @@ private fun OnboardingContentScreenEmptyPreview() {
 
     FlintTheme {
         OnboardingContentScreen(
-            nickname = "안비",
             contentUiState = OnboardingContentUiState(
                 searchKeyword = text
             ),
@@ -414,7 +394,6 @@ private fun OnboardingContentScreenGenreInteractivePreview() {
 
     FlintTheme {
         OnboardingContentScreen(
-            nickname = "안비",
             contentUiState = OnboardingContentUiState(
                 searchResults = UiState.Success(SearchContentListModel.FakeList),
                 selectedGenres = selectedGenres,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -56,7 +56,7 @@ import com.flint.core.designsystem.theme.FlintTheme
 @Composable
 fun OnboardingProfileRoute(
     paddingValues: PaddingValues,
-    navigateToOnboardingContent: () -> Unit,
+    navigateToOnboardingDone: () -> Unit,
     navigateUp: () -> Unit,
     viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
@@ -76,7 +76,7 @@ fun OnboardingProfileRoute(
         onCheckNickname = viewModel::checkNicknameDuplication,
         onProfileImageSelected = viewModel::updateProfileImage,
         onBackClick = navigateUp,
-        onNextClick = navigateToOnboardingContent,
+        onNextClick = navigateToOnboardingDone,
         modifier = Modifier
             .padding(paddingValues)
             .consumeWindowInsets(paddingValues),

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -329,7 +329,7 @@ private fun OnboardingProfileScreenFormatErrorPreview() {
             isFormatValid = false,
             isNicknameAvailable = null,
             canProceed = false,
-            canCheckNickname = false,
+            canCheckNickname = true,
             profileImageUri = null,
             showToast = true,
             toastMessage = "사용할 수 없는 닉네임입니다",

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -52,6 +52,7 @@ import com.flint.core.designsystem.component.textfield.FlintBasicTextField
 import com.flint.core.designsystem.component.toast.ShowToast
 import com.flint.core.designsystem.component.topappbar.FlintBackTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
+import com.flint.presentation.onboarding.event.OnboardingProfileEvent
 
 @Composable
 fun OnboardingProfileRoute(
@@ -62,6 +63,22 @@ fun OnboardingProfileRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    var showToast by remember { mutableStateOf(false) }
+    var toastMessage by remember { mutableStateOf("") }
+    var isToastSuccess by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.profileEvent.collect { event ->
+            when (event) {
+                is OnboardingProfileEvent.ShowNicknameToast -> {
+                    toastMessage = event.message
+                    isToastSuccess = event.isSuccess
+                    showToast = true
+                }
+            }
+        }
+    }
+
     OnboardingProfileScreen(
         nickname = uiState.nickname,
         isValid = uiState.isValid,
@@ -69,9 +86,11 @@ fun OnboardingProfileRoute(
         isNicknameAvailable = uiState.isNicknameAvailable,
         canProceed = uiState.canProceed,
         canCheckNickname = uiState.canCheckNickname,
-        hasError = uiState.hasError,
-        errorMessage = uiState.errorMessage,
         profileImageUri = uiState.profileImageUri,
+        showToast = showToast,
+        toastMessage = toastMessage,
+        isToastSuccess = isToastSuccess,
+        onToastHide = { showToast = false },
         onNicknameChange = viewModel::updateNickname,
         onCheckNickname = viewModel::checkNicknameDuplication,
         onProfileImageSelected = viewModel::updateProfileImage,
@@ -92,9 +111,11 @@ fun OnboardingProfileScreen(
     isNicknameAvailable: Boolean?,
     canProceed: Boolean,
     canCheckNickname: Boolean,
-    hasError: Boolean,
-    errorMessage: String?,
     profileImageUri: Uri?,
+    showToast: Boolean,
+    toastMessage: String,
+    isToastSuccess: Boolean,
+    onToastHide: () -> Unit,
     onNicknameChange: (String) -> Unit,
     onCheckNickname: () -> Unit,
     onProfileImageSelected: (Uri?) -> Unit,
@@ -103,31 +124,12 @@ fun OnboardingProfileScreen(
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    var showToast by remember { mutableStateOf(false) }
-    var toastMessage by remember { mutableStateOf("") }
-    var isToastSuccess by remember { mutableStateOf(false) }
     var showProfileBottomSheet by remember { mutableStateOf(false) }
 
     val galleryLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia()
     ) { uri ->
         if (uri != null) onProfileImageSelected(uri)
-    }
-
-    LaunchedEffect(hasError, errorMessage) {
-        if (hasError && errorMessage != null) {
-            toastMessage = errorMessage
-            isToastSuccess = false
-            showToast = true
-        }
-    }
-
-    LaunchedEffect(isNicknameAvailable) {
-        if (isNicknameAvailable == true) {
-            toastMessage = "사용 가능한 닉네임입니다"
-            isToastSuccess = true
-            showToast = true
-        }
     }
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -259,7 +261,7 @@ fun OnboardingProfileScreen(
                 ),
                 paddingValues = PaddingValues.Zero,
                 yOffset = 100.dp,
-                hide = { showToast = false },
+                hide = onToastHide,
             )
         }
     }
@@ -276,9 +278,11 @@ private fun OnboardingProfileScreenPreview() {
             isNicknameAvailable = true,
             canProceed = true,
             canCheckNickname = true,
-            hasError = false,
-            errorMessage = null,
             profileImageUri = null,
+            showToast = false,
+            toastMessage = "",
+            isToastSuccess = false,
+            onToastHide = {},
             onNicknameChange = {},
             onCheckNickname = {},
             onProfileImageSelected = {},
@@ -299,9 +303,11 @@ private fun OnboardingProfileScreenDuplicateErrorPreview() {
             isNicknameAvailable = false,
             canProceed = false,
             canCheckNickname = true,
-            hasError = true,
-            errorMessage = "이미 사용 중인 닉네임입니다",
             profileImageUri = null,
+            showToast = true,
+            toastMessage = "이미 사용 중인 닉네임입니다",
+            isToastSuccess = false,
+            onToastHide = {},
             onNicknameChange = {},
             onCheckNickname = {},
             onProfileImageSelected = {},
@@ -324,9 +330,11 @@ private fun OnboardingProfileScreenFormatErrorPreview() {
             isNicknameAvailable = null,
             canProceed = false,
             canCheckNickname = false,
-            hasError = true,
-            errorMessage = "사용할 수 없는 닉네임입니다",
             profileImageUri = null,
+            showToast = true,
+            toastMessage = "사용할 수 없는 닉네임입니다",
+            isToastSuccess = false,
+            onToastHide = {},
             onNicknameChange = { text = it },
             onCheckNickname = {},
             onProfileImageSelected = {},

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingTermsScreen.kt
@@ -48,7 +48,7 @@ import com.flint.domain.model.terms.TermModel
 fun OnboardingTermsRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
-    navigateToOnboardingProfile: () -> Unit,
+    navigateToOnboardingContent: () -> Unit,
     viewModel: OnboardingViewModel,
 ) {
     val termsUiState by viewModel.termsUiState.collectAsStateWithLifecycle()
@@ -62,7 +62,7 @@ fun OnboardingTermsRoute(
         onBackClick = navigateUp,
         onAgreeClick = { agreedIds ->
             viewModel.agreeToTerms(agreedIds)
-            navigateToOnboardingProfile()
+            navigateToOnboardingContent()
         },
         modifier = Modifier.padding(paddingValues),
     )

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -29,16 +29,15 @@ data class OnboardingProfileUiState(
     companion object {
         const val MAX_LENGTH = 8
         const val MIN_LENGTH = 2
-        private val NICKNAME_REGEX = Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z]+$")
-        private val STANDALONE_KOREAN_REGEX = Regex("[ㄱ-ㅎㅏ-ㅣ]")
+
+        // 완성된 한글 음절(가-힣)과 영문만 허용. 자음/모음만 단독으로 입력된 경우(ㄱ-ㅎ, ㅏ-ㅣ)는
+        // 제외되어 있어 "ㅇㄴㄹ", "ㅏㅏ" 같은 입력도 형식 오류로 처리된다.
+        private val NICKNAME_REGEX = Regex("^[가-힣a-zA-Z]+$")
 
         fun isValidFormat(nickname: String): Boolean {
             return nickname.isEmpty() || NICKNAME_REGEX.matches(nickname)
         }
     }
-
-    val hasStandaloneKorean: Boolean
-        get() = STANDALONE_KOREAN_REGEX.containsMatchIn(nickname)
 
     val hasError: Boolean
         get() = nicknameErrorType != null
@@ -50,12 +49,13 @@ data class OnboardingProfileUiState(
             null -> null
         }
 
+    // 형식 오류(자모 단독 입력 포함) 여부와 무관하게 2자 이상이면 활성화 — 형식 검증은 버튼 클릭 시 수행
     val canCheckNickname: Boolean
-        get() = isValid && isFormatValid && !hasStandaloneKorean
+        get() = isValid
 
     //다음단계 활성화
     val canProceed: Boolean
-        get() = isValid && isFormatValid && isNicknameAvailable == true && !hasStandaloneKorean
+        get() = isValid && isFormatValid && isNicknameAvailable == true
 }
 
 data class OnboardingContentUiState(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingUiState.kt
@@ -31,7 +31,7 @@ data class OnboardingProfileUiState(
         const val MIN_LENGTH = 2
       
         // 완성된 한글 음절(가-힣), 영문, 숫자만 허용. 자음/모음만 단독으로 입력된 경우 "ㅇㄴㄹ", "ㅏㅏ" 같은 입력도 형식 오류로 처리된다.
-        private val NICKNAME_REGEX = Regex("^[가-힣a-zA-Z0-9]+$"
+        private val NICKNAME_REGEX = Regex("^[가-힣a-zA-Z0-9]+$")
 
         fun isValidFormat(nickname: String): Boolean {
             return nickname.isEmpty() || NICKNAME_REGEX.matches(nickname)

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -135,6 +135,9 @@ class OnboardingViewModel
 
         viewModelScope.launch {
             userRepository.checkNickname(currentNickname).onSuccess { result ->
+                // 응답이 오는 사이 닉네임이 바뀌었다면 이미 stale한 결과이므로 반영하지 않음
+                if (currentNickname != _uiState.value.nickname) return@onSuccess
+
                 _uiState.update { currentState ->
                     currentState.copy(
                         isNicknameAvailable = result.isAvailable,

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -18,13 +18,16 @@ import com.flint.domain.repository.UserRepository
 import com.flint.domain.type.FileExtension
 import com.flint.domain.type.OttType
 import com.flint.domain.type.StoragePathType
+import com.flint.presentation.onboarding.event.OnboardingProfileEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -61,6 +64,11 @@ class OnboardingViewModel
     private val _signupUiState = MutableStateFlow(OnboardingSignupUiState())
     val signupUiState: StateFlow<OnboardingSignupUiState> = _signupUiState.asStateFlow()
 
+    // 닉네임 검사 결과 토스트는 상태가 아니라 1회성 이벤트로 내려줘야
+    // 화면 재진입(예: Done에서 뒤로가기) 시 토스트가 재발생하지 않는다.
+    private val _profileEvent = MutableSharedFlow<OnboardingProfileEvent>()
+    val profileEvent = _profileEvent.asSharedFlow()
+
     private var searchJob: Job? = null
 
     // ---------- onboarding terms ----------
@@ -90,14 +98,29 @@ class OnboardingViewModel
     fun updateNickname(nickname: String) {
         if (nickname.length <= OnboardingProfileUiState.MAX_LENGTH) {
             val isFormatValid = OnboardingProfileUiState.isValidFormat(nickname)
+            val previousErrorType = _uiState.value.nicknameErrorType
+            val newErrorType = if (!isFormatValid && nickname.isNotEmpty()) NicknameErrorType.INVALID_FORMAT else null
+
             _uiState.update { currentState ->
                 currentState.copy(
                     nickname = nickname,
                     isValid = nickname.length >= OnboardingProfileUiState.MIN_LENGTH,
                     isFormatValid = isFormatValid,
                     isNicknameAvailable = null,
-                    nicknameErrorType = if (!isFormatValid && nickname.isNotEmpty()) NicknameErrorType.INVALID_FORMAT else null,
+                    nicknameErrorType = newErrorType,
                 )
+            }
+
+            // 형식 오류가 새로 발생했을 때만 토스트 이벤트 발행 (같은 오류 유지 중엔 재발행 안 함)
+            if (newErrorType == NicknameErrorType.INVALID_FORMAT && previousErrorType != NicknameErrorType.INVALID_FORMAT) {
+                viewModelScope.launch {
+                    _profileEvent.emit(
+                        OnboardingProfileEvent.ShowNicknameToast(
+                            message = "사용할 수 없는 닉네임입니다",
+                            isSuccess = false,
+                        )
+                    )
+                }
             }
         }
     }
@@ -122,6 +145,21 @@ class OnboardingViewModel
                         },
                     )
                 }
+
+                // 버튼 클릭 시점에만 발행되는 1회성 이벤트라 화면 재진입 시엔 다시 뜨지 않음
+                _profileEvent.emit(
+                    if (result.isAvailable) {
+                        OnboardingProfileEvent.ShowNicknameToast(
+                            message = "사용 가능한 닉네임입니다",
+                            isSuccess = true,
+                        )
+                    } else {
+                        OnboardingProfileEvent.ShowNicknameToast(
+                            message = "이미 사용 중인 닉네임입니다",
+                            isSuccess = false,
+                        )
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -70,6 +70,7 @@ class OnboardingViewModel
     val profileEvent = _profileEvent.asSharedFlow()
 
     private var searchJob: Job? = null
+    private var nicknameCheckJob: Job? = null
 
     // ---------- onboarding terms ----------
     fun loadTerms() {
@@ -98,29 +99,17 @@ class OnboardingViewModel
     fun updateNickname(nickname: String) {
         if (nickname.length <= OnboardingProfileUiState.MAX_LENGTH) {
             val isFormatValid = OnboardingProfileUiState.isValidFormat(nickname)
-            val previousErrorType = _uiState.value.nicknameErrorType
-            val newErrorType = if (!isFormatValid && nickname.isNotEmpty()) NicknameErrorType.INVALID_FORMAT else null
 
+            // 형식 오류 토스트는 여기서 발행하지 않음 — "확인" 버튼을 눌렀을 때만 발행한다.
+            // (타이핑 중 매 글자마다 토스트가 뜨는 문제 방지. 테두리 색은 isFormatValid로 계속 즉시 반영됨)
             _uiState.update { currentState ->
                 currentState.copy(
                     nickname = nickname,
                     isValid = nickname.length >= OnboardingProfileUiState.MIN_LENGTH,
                     isFormatValid = isFormatValid,
                     isNicknameAvailable = null,
-                    nicknameErrorType = newErrorType,
+                    nicknameErrorType = if (!isFormatValid && nickname.isNotEmpty()) NicknameErrorType.INVALID_FORMAT else null,
                 )
-            }
-
-            // 형식 오류가 새로 발생했을 때만 토스트 이벤트 발행 (같은 오류 유지 중엔 재발행 안 함)
-            if (newErrorType == NicknameErrorType.INVALID_FORMAT && previousErrorType != NicknameErrorType.INVALID_FORMAT) {
-                viewModelScope.launch {
-                    _profileEvent.emit(
-                        OnboardingProfileEvent.ShowNicknameToast(
-                            message = "사용할 수 없는 닉네임입니다",
-                            isSuccess = false,
-                        )
-                    )
-                }
             }
         }
     }
@@ -128,42 +117,56 @@ class OnboardingViewModel
     fun checkNicknameDuplication() {
         val currentNickname = _uiState.value.nickname
 
-        // 형식이 유효하지 않으면 중복 체크 실행하지 않음
+        // 형식이 유효하지 않으면(자모 단독 입력 포함) 서버 호출 없이 형식 오류 토스트만 노출
         if (!_uiState.value.isFormatValid) {
+            viewModelScope.launch {
+                _profileEvent.emit(
+                    OnboardingProfileEvent.ShowNicknameToast(
+                        message = "사용할 수 없는 닉네임입니다",
+                        isSuccess = false,
+                    )
+                )
+            }
             return
         }
 
-        viewModelScope.launch {
-            userRepository.checkNickname(currentNickname).onSuccess { result ->
-                // 응답이 오는 사이 닉네임이 바뀌었다면 이미 stale한 결과이므로 반영하지 않음
-                if (currentNickname != _uiState.value.nickname) return@onSuccess
+        // 연타 시 이전 요청을 취소해 중복 요청과 토스트 중복 발행을 방지
+        nicknameCheckJob?.cancel()
+        nicknameCheckJob = viewModelScope.launch {
+            userRepository.checkNickname(currentNickname)
+                .onSuccess { result ->
+                    // 응답이 오는 사이 닉네임이 바뀌었다면 이미 stale한 결과이므로 반영하지 않음
+                    if (currentNickname != _uiState.value.nickname) return@onSuccess
 
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        isNicknameAvailable = result.isAvailable,
-                        nicknameErrorType = if (!result.isAvailable) {
-                            NicknameErrorType.DUPLICATE
-                        } else {
-                            null
-                        },
-                    )
-                }
-
-                // 버튼 클릭 시점에만 발행되는 1회성 이벤트라 화면 재진입 시엔 다시 뜨지 않음
-                _profileEvent.emit(
-                    if (result.isAvailable) {
-                        OnboardingProfileEvent.ShowNicknameToast(
-                            message = "사용 가능한 닉네임입니다",
-                            isSuccess = true,
-                        )
-                    } else {
-                        OnboardingProfileEvent.ShowNicknameToast(
-                            message = "이미 사용 중인 닉네임입니다",
-                            isSuccess = false,
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            isNicknameAvailable = result.isAvailable,
+                            nicknameErrorType = if (!result.isAvailable) {
+                                NicknameErrorType.DUPLICATE
+                            } else {
+                                null
+                            },
                         )
                     }
-                )
-            }
+
+                    // 버튼 클릭 시점에만 발행되는 1회성 이벤트라 화면 재진입 시엔 다시 뜨지 않음
+                    _profileEvent.emit(
+                        if (result.isAvailable) {
+                            OnboardingProfileEvent.ShowNicknameToast(
+                                message = "사용 가능한 닉네임입니다",
+                                isSuccess = true,
+                            )
+                        } else {
+                            OnboardingProfileEvent.ShowNicknameToast(
+                                message = "이미 사용 중인 닉네임입니다",
+                                isSuccess = false,
+                            )
+                        }
+                    )
+                }
+                .onFailure { error ->
+                     Timber.e(error, "닉네임 중복검사 실패했습니다.")
+                }
         }
     }
 

--- a/app/src/main/java/com/flint/presentation/onboarding/event/OnboardingProfileEvent.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/event/OnboardingProfileEvent.kt
@@ -1,0 +1,5 @@
+package com.flint.presentation.onboarding.event
+
+sealed interface OnboardingProfileEvent {
+    data class ShowNicknameToast(val message: String, val isSuccess: Boolean) : OnboardingProfileEvent
+}

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -58,9 +58,20 @@ fun NavGraphBuilder.onBoardingNavGraph(
             OnboardingTermsRoute(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
-                navigateToOnboardingProfile = navController::navigateToOnboardingProfile,
+                navigateToOnboardingContent = navController::navigateToOnboardingContent,
                 viewModel = sharedViewModel,
             )
+        }
+
+            composable<Route.OnboardingContent> { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
+
+            OnboardingContentRoute(
+                paddingValues = paddingValues,
+                navigateUp = navController::navigateUp,
+                navigateToOnboardingProfile = navController::navigateToOnboardingProfile,
+                viewModel = sharedViewModel,
+                )
         }
 
         composable<Route.OnboardingProfile> { backStackEntry ->
@@ -69,20 +80,9 @@ fun NavGraphBuilder.onBoardingNavGraph(
             OnboardingProfileRoute(
                 paddingValues = paddingValues,
                 navigateUp = navController::navigateUp,
-                navigateToOnboardingContent = navController::navigateToOnboardingContent,
-                viewModel = sharedViewModel,
-            )
-        }
-
-        composable<Route.OnboardingContent> { backStackEntry ->
-            val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
-
-            OnboardingContentRoute(
-                paddingValues = paddingValues,
-                navigateUp = navController::navigateUp,
                 navigateToOnboardingDone = navController::navigateToOnboardingDone,
                 viewModel = sharedViewModel,
-                )
+            )
         }
 
         composable<Route.OnboardingOtt> { backStackEntry ->

--- a/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -63,7 +63,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
             )
         }
 
-            composable<Route.OnboardingContent> { backStackEntry ->
+        composable<Route.OnboardingContent> { backStackEntry ->
             val sharedViewModel = backStackEntry.sharedViewModel<OnboardingViewModel>(navController)
 
             OnboardingContentRoute(
@@ -71,7 +71,7 @@ fun NavGraphBuilder.onBoardingNavGraph(
                 navigateUp = navController::navigateUp,
                 navigateToOnboardingProfile = navController::navigateToOnboardingProfile,
                 viewModel = sharedViewModel,
-                )
+            )
         }
 
         composable<Route.OnboardingProfile> { backStackEntry ->

--- a/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,7 +29,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.flint.core.common.extension.findActivity
 import com.flint.core.common.extension.noRippleClickable
 import com.flint.R
 import androidx.compose.material3.Icon
@@ -51,7 +49,6 @@ import com.flint.domain.model.ott.OttListModel
 import com.flint.domain.model.ott.OttModel
 import com.flint.domain.model.user.KeywordListModel
 import com.flint.domain.model.user.UserProfileResponseModel
-import com.flint.presentation.MainActivity
 import com.flint.presentation.profile.component.ProfileKeywordSection
 import com.flint.presentation.profile.component.ProfileTopSection
 import com.flint.presentation.profile.sideeffect.ProfileSideEffect
@@ -73,7 +70,6 @@ fun ProfileRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = LocalUriHandler.current
-    val context = LocalContext.current
 
     var showOttListBottomSheet by remember { mutableStateOf(false) }
     var ottListModel by remember { mutableStateOf(OttListModel()) }
@@ -93,14 +89,6 @@ fun ProfileRoute(
                     ottListModel = sideEffect.ottListModel
                     if (ottListModel.otts.isNotEmpty()) {
                         showOttListBottomSheet = true
-                    }
-                }
-                is ProfileSideEffect.WithdrawSuccess -> {
-                    val activity = context.findActivity() as? MainActivity
-                    if (activity != null) {
-                        activity.restartApplication()
-                    } else {
-                        //TODO: Fallback: 앱 재시작이 불가능할 경우, 다른 처리 로직을 여기에 작성
                     }
                 }
             }
@@ -134,7 +122,6 @@ fun ProfileRoute(
             )
         },
         onRefreshClick = viewModel::recalculateKeywords,
-        onEasterEggWithdraw = viewModel::easterEggWithdraw,
     )
 
     if (showOttListBottomSheet) {
@@ -158,7 +145,6 @@ private fun ProfileScreen(
     onContentMoreClick: () -> Unit = {},
     onCreatedCollectionMoreClick: () -> Unit,
     onSavedCollectionMoreClick: () -> Unit,
-    onEasterEggWithdraw: () -> Unit = {},
 ) {
     val userName = uiState.profile.nickname
     var topHeightPx by remember { mutableIntStateOf(0) }
@@ -186,11 +172,6 @@ private fun ProfileScreen(
                             userName = nickname,
                             profileUrl = profileImageUrl.orEmpty(),
                             isFliner = isFliner,
-                            onEasterEggWithdraw = {
-                                if (uiState.userId == null) {
-                                    onEasterEggWithdraw()
-                                }
-                            },
                         )
                     }
                 }

--- a/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/profile/ProfileViewModel.kt
@@ -9,7 +9,6 @@ import com.flint.core.common.util.suspendRunCatching
 import com.flint.core.navigation.Route
 import com.flint.domain.model.bookmark.BookmarkChange
 import com.flint.domain.model.user.KeywordListModel
-import com.flint.domain.repository.AuthRepository
 import com.flint.domain.repository.BookmarkRepository
 import com.flint.domain.repository.ContentRepository
 import com.flint.domain.repository.UserRepository
@@ -32,7 +31,6 @@ import javax.inject.Inject
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val authRepository: AuthRepository,
     private val userRepository: UserRepository,
     private val contentRepository: ContentRepository,
     private val bookmarkRepository: BookmarkRepository,
@@ -177,15 +175,5 @@ class ProfileViewModel @Inject constructor(
             }
             .onFailure { Timber.e(it) }
         _uiState.update { it.copy(isRecalculating = false) }
-    }
-
-    fun easterEggWithdraw() = viewModelScope.launch {
-        authRepository.withdraw()
-            .onSuccess {
-                _sideEffect.emit(ProfileSideEffect.WithdrawSuccess)
-            }
-            .onFailure {
-                Timber.e(it)
-            }
     }
 }

--- a/app/src/main/java/com/flint/presentation/profile/component/ProfileTopSection.kt
+++ b/app/src/main/java/com/flint/presentation/profile/component/ProfileTopSection.kt
@@ -13,11 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
@@ -28,12 +23,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.flint.R
-import com.flint.core.common.extension.noRippleClickable
 import com.flint.core.designsystem.component.image.ProfileImage
 import com.flint.core.designsystem.theme.FlintTheme
-
-private const val EASTER_EGG_CLICK_COUNT = 5
-private const val EASTER_EGG_CLICK_TIMEOUT = 3000L
 
 @Composable
 fun ProfileTopSection(
@@ -41,11 +32,7 @@ fun ProfileTopSection(
     profileUrl: String,
     isFliner: Boolean,
     modifier: Modifier = Modifier,
-    onEasterEggWithdraw: () -> Unit = {},
 ) {
-    var clickCount by remember { mutableIntStateOf(0) }
-    var lastClickTime by remember { mutableLongStateOf(0L) }
-
     Column {
         Box(
             modifier =
@@ -97,22 +84,6 @@ fun ProfileTopSection(
                         .offset(x = 13.dp, y = (-42).dp)
                         .align(Alignment.BottomStart)
                         .size(128.dp)
-                        .noRippleClickable(
-                            onClick = {
-                                val currentTime = System.currentTimeMillis()
-                                if (currentTime - lastClickTime > EASTER_EGG_CLICK_TIMEOUT) {
-                                    clickCount = 1
-                                } else {
-                                    clickCount++
-                                }
-                                lastClickTime = currentTime
-
-                                if (clickCount >= EASTER_EGG_CLICK_COUNT) {
-                                    clickCount = 0
-                                    onEasterEggWithdraw()
-                                }
-                            }
-                        )
             )
         }
     }

--- a/app/src/main/java/com/flint/presentation/profile/sideeffect/ProfileSideEffect.kt
+++ b/app/src/main/java/com/flint/presentation/profile/sideeffect/ProfileSideEffect.kt
@@ -4,5 +4,4 @@ import com.flint.domain.model.ott.OttListModel
 
 sealed interface ProfileSideEffect {
     data class ShowOttListBottomSheet(val ottListModel: OttListModel) : ProfileSideEffect
-    data object WithdrawSuccess : ProfileSideEffect
 }


### PR DESCRIPTION
## 📮 관련 이슈
- closed #이슈번호

## 📌 작업 내용
- 온보딩 화면 순서 변경: 닉네임 입력 → 좋아하는 작품 선택 순서로 조정 (Content 화면 타이틀에서 닉네임 문구 제거)
- 닉네임 중복확인 결과 토스트를 상태 기반에서 1회성 이벤트(SharedFlow)로 변경 → Done 화면에서 뒤로가기로 프로필 화면에 재진입해도 토스트가 다시 뜨지 않도록 수정
- 온보딩 콘텐츠 화면 타이틀 텍스트를 한 줄 우선으로 배치하고, 좌우 16dp 패딩 안에서 한 줄로 안 들어갈 때만 수동 줄바꿈되도록 개선
- 프로필 사진 5회 연타(3초 이내) 시 바로 회원탈퇴되던 이스터에그 로직 제거 (설정 > 회원탈퇴 화면으로 대체됨)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 온보딩 진행 순서가 약관 동의 → 콘텐츠 → 프로필 → 완료로 변경되었습니다.
  - 닉네임 중복 확인 결과에 따라 성공 또는 오류 토스트가 표시됩니다.
  - 최신 닉네임 확인 결과만 반영됩니다.

- **개선 사항**
  - 닉네임은 완성형 한글 음절과 영문만 허용됩니다.
  - 닉네임 형식 오류는 확인 시 안내됩니다.
  - 온보딩 콘텐츠 화면 제목이 고정 문구로 변경되었습니다.
  - 프로필 화면에서 숨겨진 회원 탈퇴 동작이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->