### PR TITLE
[FIX] 안드자체 QA 수정사항 반영 (온보딩/탐색)

### DIFF
--- a/app/src/main/java/com/flint/data/api/ExplorationApi.kt
+++ b/app/src/main/java/com/flint/data/api/ExplorationApi.kt
@@ -1,0 +1,14 @@
+package com.flint.data.api
+
+import com.flint.data.dto.base.BaseResponse
+import com.flint.data.dto.exploration.response.ExplorationResponseDto
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface ExplorationApi {
+    @GET("/api/v1/exploration")
+    suspend fun getExplorationSession(): BaseResponse<ExplorationResponseDto>
+
+    @POST("/api/v1/exploration/next")
+    suspend fun advanceToNextExplorationSession(): BaseResponse<ExplorationResponseDto>
+}

--- a/app/src/main/java/com/flint/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/flint/data/di/ServiceModule.kt
@@ -4,6 +4,7 @@ import com.flint.data.api.AuthApi
 import com.flint.data.api.BookmarkApi
 import com.flint.data.api.CollectionApi
 import com.flint.data.api.ContentApi
+import com.flint.data.api.ExplorationApi
 import com.flint.data.api.HomeApi
 import com.flint.data.api.SearchApi
 import com.flint.data.api.StorageApi
@@ -54,4 +55,8 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideTermsApi(retrofit: Retrofit): TermsApi = retrofit.create(TermsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideExplorationApi(retrofit: Retrofit): ExplorationApi = retrofit.create(ExplorationApi::class.java)
 }

--- a/app/src/main/java/com/flint/data/dto/exploration/response/ExplorationResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/exploration/response/ExplorationResponseDto.kt
@@ -1,0 +1,22 @@
+package com.flint.data.dto.exploration.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExplorationResponseDto(
+    @SerialName("items") val items: List<Item>,
+    // IN_PROGRESS / END / EMPTY
+    @SerialName("state") val state: String,
+    @SerialName("hasNext") val hasNext: Boolean,
+) {
+    @Serializable
+    data class Item(
+        @SerialName("contentId") val contentId: String,
+        @SerialName("title") val title: String,
+        @SerialName("description") val description: String,
+        @SerialName("imageUrl") val imageUrl: String,
+        @SerialName("year") val year: Int,
+        @SerialName("collectionId") val collectionId: String,
+    )
+}

--- a/app/src/main/java/com/flint/data/dto/exploration/response/ExplorationResponseDto.kt
+++ b/app/src/main/java/com/flint/data/dto/exploration/response/ExplorationResponseDto.kt
@@ -14,9 +14,9 @@ data class ExplorationResponseDto(
     data class Item(
         @SerialName("contentId") val contentId: String,
         @SerialName("title") val title: String,
-        @SerialName("description") val description: String,
-        @SerialName("imageUrl") val imageUrl: String,
-        @SerialName("year") val year: Int,
-        @SerialName("collectionId") val collectionId: String,
+        @SerialName("description") val description: String = "",
+        @SerialName("imageUrl") val imageUrl: String = "",
+        @SerialName("year") val year: Int? = null,
+        @SerialName("collectionId") val collectionId: String = "",
     )
 }

--- a/app/src/main/java/com/flint/domain/mapper/exploration/ExplorationMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/exploration/ExplorationMapper.kt
@@ -31,6 +31,6 @@ private fun ExplorationResponseDto.Item.toModel(): ExplorationItemModel =
         title = title,
         description = description,
         imageUrl = imageUrl,
-        year = year,
+        year = year ?: 0,
         collectionId = collectionId,
     )

--- a/app/src/main/java/com/flint/domain/mapper/exploration/ExplorationMapper.kt
+++ b/app/src/main/java/com/flint/domain/mapper/exploration/ExplorationMapper.kt
@@ -1,0 +1,36 @@
+package com.flint.domain.mapper.exploration
+
+import com.flint.data.dto.exploration.response.ExplorationResponseDto
+import com.flint.domain.model.exploration.ExplorationItemModel
+import com.flint.domain.model.exploration.ExplorationSessionModel
+import com.flint.domain.model.exploration.ExplorationState
+import kotlinx.collections.immutable.toImmutableList
+import timber.log.Timber
+
+fun ExplorationResponseDto.toModel(): ExplorationSessionModel =
+    ExplorationSessionModel(
+        items = items.map { it.toModel() }.toImmutableList(),
+        state = state.toExplorationState(),
+        hasNext = hasNext,
+    )
+
+private fun String.toExplorationState(): ExplorationState =
+    when (this) {
+        "IN_PROGRESS" -> ExplorationState.IN_PROGRESS
+        "END" -> ExplorationState.END
+        "EMPTY" -> ExplorationState.EMPTY
+        else -> {
+            Timber.e("알 수 없는 탐색 state 값: $this")
+            ExplorationState.UNKNOWN
+        }
+    }
+
+private fun ExplorationResponseDto.Item.toModel(): ExplorationItemModel =
+    ExplorationItemModel(
+        contentId = contentId,
+        title = title,
+        description = description,
+        imageUrl = imageUrl,
+        year = year,
+        collectionId = collectionId,
+    )

--- a/app/src/main/java/com/flint/domain/model/exploration/ExplorationModel.kt
+++ b/app/src/main/java/com/flint/domain/model/exploration/ExplorationModel.kt
@@ -1,0 +1,31 @@
+package com.flint.domain.model.exploration
+
+import kotlinx.collections.immutable.ImmutableList
+
+enum class ExplorationState {
+    IN_PROGRESS,
+    END,
+    EMPTY,
+    UNKNOWN,
+}
+
+data class ExplorationSessionModel(
+    val items: ImmutableList<ExplorationItemModel>,
+    val state: ExplorationState,
+    val hasNext: Boolean,
+) {
+    val isEnd: Boolean
+        get() = state == ExplorationState.END
+
+    val isEmpty: Boolean
+        get() = state == ExplorationState.EMPTY
+}
+
+data class ExplorationItemModel(
+    val contentId: String,
+    val title: String,
+    val description: String,
+    val imageUrl: String,
+    val year: Int,
+    val collectionId: String,
+)

--- a/app/src/main/java/com/flint/domain/repository/ExplorationRepository.kt
+++ b/app/src/main/java/com/flint/domain/repository/ExplorationRepository.kt
@@ -1,0 +1,21 @@
+package com.flint.domain.repository
+
+import com.flint.core.common.util.suspendRunCatching
+import com.flint.data.api.ExplorationApi
+import com.flint.domain.mapper.exploration.toModel
+import com.flint.domain.model.exploration.ExplorationSessionModel
+import javax.inject.Inject
+
+class ExplorationRepository @Inject constructor(
+    private val apiService: ExplorationApi,
+) {
+    suspend fun getExplorationSession(): Result<ExplorationSessionModel> =
+        suspendRunCatching {
+            apiService.getExplorationSession().data.toModel()
+        }
+
+    suspend fun advanceToNextExplorationSession(): Result<ExplorationSessionModel> =
+        suspendRunCatching {
+            apiService.advanceToNextExplorationSession().data.toModel()
+        }
+}

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -98,10 +98,9 @@ private fun ExploreScreen(
     modifier: Modifier = Modifier,
 ) {
     val itemCount: Int = items.size
-    val totalPageCount: Int = if (isEnd) itemCount + 1 else itemCount
     val pagerState: PagerState = rememberPagerState(
         initialPage = initialPage,
-        pageCount = { totalPageCount },
+        pageCount = { itemCount + 1 },
     )
 
     LaunchedEffect(pagerState.currentPage) {

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -180,7 +180,7 @@ private fun ExplorePageItem(
 
         Column(modifier.padding(horizontal = 16.dp)) {
             Text(
-                text = "$contentTitle ($year)",
+                text = contentTitle,
                 color = FlintTheme.colors.white,
                 style = FlintTheme.typography.display2M28,
                 maxLines = 2,

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -76,6 +76,13 @@ fun ExploreRoute(
             }
         }
 
+        UiState.Failure -> {
+            ExploreErrorPage(
+                onRetryClick = viewModel::retry,
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
+
         else -> {}
     }
 }
@@ -91,9 +98,10 @@ private fun ExploreScreen(
     modifier: Modifier = Modifier,
 ) {
     val itemCount: Int = items.size
+    val totalPageCount: Int = if (isEnd) itemCount + 1 else itemCount
     val pagerState: PagerState = rememberPagerState(
         initialPage = initialPage,
-        pageCount = { itemCount + 1 },
+        pageCount = { totalPageCount },
     )
 
     LaunchedEffect(pagerState.currentPage) {
@@ -123,20 +131,36 @@ private fun ExploreScreen(
         ) { page: Int ->
             val item: ExplorationItemModel? = items.getOrNull(page)
 
-            if (item != null) {
-                ExplorePageItem(
-                    imageUrl = item.imageUrl,
-                    collectionId = item.collectionId,
-                    contentTitle = item.title,
-                    contentDescription = item.description,
-                    year = item.year,
-                    onButtonClick = { onWatchCollectionButtonClick(it, item.imageUrl) },
-                )
-            } else {
-                ExploreEndPage(
-                    onButtonClick = onMakeCollectionButtonClick,
-                    modifier = Modifier.fillMaxSize(),
-                )
+            when {
+                item != null -> {
+                    ExplorePageItem(
+                        imageUrl = item.imageUrl,
+                        collectionId = item.collectionId,
+                        contentTitle = item.title,
+                        contentDescription = item.description,
+                        year = item.year,
+                        onButtonClick = { onWatchCollectionButtonClick(it, item.imageUrl) },
+                    )
+                }
+                // isEnd == true일 때만 진짜 End 화면을 보여준다.
+                isEnd -> {
+                    ExploreEndPage(
+                        onButtonClick = onMakeCollectionButtonClick,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+                // isEnd == false인데 item이 없는 경우(다음 세션 로딩 중/실패 등)는
+                // End로 오해하지 않도록 로딩 표시만 하고 대기한다.
+                else -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(FlintTheme.colors.background),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        FlintLoadingIndicator()
+                    }
+                }
             }
         }
     }
@@ -343,6 +367,68 @@ private fun ExploreEmptyPage(
 private fun ExploreEmptyPagePreview() {
     FlintTheme {
         ExploreEmptyPage()
+    }
+}
+
+// 탐색 세션 조회(getExplorationSession) 실패 시(state == Failure)
+@Composable
+private fun ExploreErrorPage(
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .background(FlintTheme.colors.background)
+                .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        FlintLogoTopAppbar(backgroundColor = Color.Transparent)
+
+        Spacer(Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(R.drawable.ic_gradient_pencil),
+            contentDescription = null,
+        )
+
+        Spacer(Modifier.height(47.dp))
+
+        Text(
+            text = "탐색 콘텐츠를 불러오지 못했어요",
+            color = FlintTheme.colors.white,
+            style = FlintTheme.typography.head1Sb22,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = "네트워크 상태를 확인한 뒤\n다시 시도해주세요!",
+            color = FlintTheme.colors.white,
+            style = FlintTheme.typography.body1M16,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(Modifier.weight(1f))
+
+        FlintLargeButton(
+            text = "다시 시도하기",
+            state = FlintButtonState.Able,
+            onClick = onRetryClick,
+            modifier =
+                Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 20.dp)
+                    .fillMaxWidth(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ExploreErrorPagePreview() {
+    FlintTheme {
+        ExploreErrorPage(onRetryClick = {})
     }
 }
 

--- a/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreScreen.kt
@@ -39,7 +39,7 @@ import com.flint.core.designsystem.component.image.NetworkImage
 import com.flint.core.designsystem.component.indicator.FlintLoadingIndicator
 import com.flint.core.designsystem.component.topappbar.FlintLogoTopAppbar
 import com.flint.core.designsystem.theme.FlintTheme
-import com.flint.domain.model.collection.CollectionsModel
+import com.flint.domain.model.exploration.ExplorationItemModel
 import com.flint.presentation.explore.uistate.ExploreUiState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -59,14 +59,21 @@ fun ExploreRoute(
         }
 
         is UiState.Success -> {
-            val uiState = (uiState as UiState.Success<ExploreUiState>).data
-            ExploreScreen(
-                collections = uiState.collections,
-                onWatchCollectionButtonClick = navigateToCollectionDetail,
-                onMakeCollectionButtonClick = navigateToCollectionCreate,
-                onLoadNextPage = viewModel::loadNextPage,
-                modifier = Modifier.padding(paddingValues),
-            )
+            val data = (uiState as UiState.Success<ExploreUiState>).data
+
+            if (data.isEmpty) {
+                ExploreEmptyPage(modifier = Modifier.padding(paddingValues))
+            } else {
+                ExploreScreen(
+                    items = data.items,
+                    isEnd = data.isEnd,
+                    initialPage = data.initialPage,
+                    onWatchCollectionButtonClick = navigateToCollectionDetail,
+                    onMakeCollectionButtonClick = navigateToCollectionCreate,
+                    onLoadNextSession = viewModel::advanceToNextSession,
+                    modifier = Modifier.padding(paddingValues),
+                )
+            }
         }
 
         else -> {}
@@ -75,25 +82,30 @@ fun ExploreRoute(
 
 @Composable
 private fun ExploreScreen(
-    collections: ImmutableList<CollectionsModel.Collection>,
+    items: ImmutableList<ExplorationItemModel>,
+    isEnd: Boolean,
+    initialPage: Int,
     onWatchCollectionButtonClick: (collectionId: String, imageUrl: String) -> Unit,
     onMakeCollectionButtonClick: () -> Unit,
-    onLoadNextPage: () -> Unit,
+    onLoadNextSession: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val pageCount: Int = collections.size
-    val pagerState: PagerState = rememberPagerState(pageCount = { pageCount + 1 })
+    val itemCount: Int = items.size
+    val pagerState: PagerState = rememberPagerState(
+        initialPage = initialPage,
+        pageCount = { itemCount + 1 },
+    )
 
     LaunchedEffect(pagerState.currentPage) {
-        if (pagerState.currentPage >= pageCount - 3 && pageCount > 0) {
-            onLoadNextPage()
+        if (!isEnd && pagerState.currentPage >= itemCount - 3 && itemCount > 0) {
+            onLoadNextSession()
         }
     }
 
     Column(
         modifier
             .run {
-                if (pagerState.currentPage < pageCount) {
+                if (pagerState.currentPage < itemCount) {
                     background(FlintTheme.colors.background)
                 } else {
                     background(
@@ -109,15 +121,16 @@ private fun ExploreScreen(
             state = pagerState,
             modifier = Modifier.fillMaxSize(),
         ) { page: Int ->
-            val collection: CollectionsModel.Collection? = collections.getOrNull(page)
+            val item: ExplorationItemModel? = items.getOrNull(page)
 
-            if (collection != null) {
+            if (item != null) {
                 ExplorePageItem(
-                    imageUrl = collection.imageUrl,
-                    id = collection.collectionId,
-                    contentTitle = collection.contentTitle,
-                    contentDescription = collection.contentDescription,
-                    onButtonClick = { onWatchCollectionButtonClick(it, collection.imageUrl) },
+                    imageUrl = item.imageUrl,
+                    collectionId = item.collectionId,
+                    contentTitle = item.title,
+                    contentDescription = item.description,
+                    year = item.year,
+                    onButtonClick = { onWatchCollectionButtonClick(it, item.imageUrl) },
                 )
             } else {
                 ExploreEndPage(
@@ -132,9 +145,10 @@ private fun ExploreScreen(
 @Composable
 private fun ExplorePageItem(
     imageUrl: String,
-    id: String,
+    collectionId: String,
     contentTitle: String,
     contentDescription: String,
+    year: Int,
     onButtonClick: (collectionId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -166,7 +180,7 @@ private fun ExplorePageItem(
 
         Column(modifier.padding(horizontal = 16.dp)) {
             Text(
-                text = contentTitle,
+                text = "$contentTitle ($year)",
                 color = FlintTheme.colors.white,
                 style = FlintTheme.typography.display2M28,
                 maxLines = 2,
@@ -188,7 +202,7 @@ private fun ExplorePageItem(
             FlintLargeButton(
                 text = "이 컬렉션 보러가기",
                 state = FlintButtonState.ColorOutline,
-                onClick = { onButtonClick(id) },
+                onClick = { onButtonClick(collectionId) },
                 modifier =
                     Modifier
                         .padding(bottom = 16.dp)
@@ -205,16 +219,17 @@ private fun ExplorePageItemPreview() {
     FlintTheme {
         ExplorePageItem(
             imageUrl = "https://buly.kr/G3Edbfu",
-            id = "",
+            collectionId = "",
             contentTitle = "너의 모든 것".repeat(10),
             contentDescription =
                 """
-                뉴욕의 서점 매니저이자 반듯한 독서가, 조. 
-                그가 대학원생 벡을 만나 한눈에 반한다. 
-                하지만 훈훈했던 그의 첫인상은 잠시일 뿐, 
+                뉴욕의 서점 매니저이자 반듯한 독서가, 조.
+                그가 대학원생 벡을 만나 한눈에 반한다.
+                하지만 훈훈했던 그의 첫인상은 잠시일 뿐,
                 감추어진 조의 뒤틀린 이면이 드러난다.
-                
+
                 """.trimIndent().repeat(10),
+            year = 2014,
             onButtonClick = {},
         )
     }
@@ -281,29 +296,83 @@ private fun ExploreEndPagePreview() {
     }
 }
 
+// 아직 첫 탐색 세션(30개)이 준비되지 않은 경우(state == EMPTY)
+@Composable
+private fun ExploreEmptyPage(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .background(FlintTheme.colors.background)
+                .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        FlintLogoTopAppbar(backgroundColor = Color.Transparent)
+
+        Spacer(Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(R.drawable.ic_gradient_pencil),
+            contentDescription = null,
+        )
+
+        Spacer(Modifier.height(47.dp))
+
+        Text(
+            text = "탐색 콘텐츠를 준비하고 있어요",
+            color = FlintTheme.colors.white,
+            style = FlintTheme.typography.head1Sb22,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = "곧 새로운 작품들로 찾아올게요\n조금만 기다려주세요!",
+            color = FlintTheme.colors.white,
+            style = FlintTheme.typography.body1M16,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+@Preview
+@Composable
+private fun ExploreEmptyPagePreview() {
+    FlintTheme {
+        ExploreEmptyPage()
+    }
+}
+
 @Preview
 @Composable
 private fun ExploreScreenPreview() {
     FlintTheme {
         ExploreScreen(
-            collections =
+            items =
                 List(10) {
-                    CollectionsModel.Collection(
-                        collectionId = "0",
-                        contentTitle = "너의 모든 것",
-                        imageUrl = "https://buly.kr/G3Edbfu",
-                        contentDescription =
+                    ExplorationItemModel(
+                        contentId = "0",
+                        title = "너의 모든 것",
+                        description =
                             """
                             뉴욕의 서점 매니저이자 반듯한 독서가, 조.
                             그가 대학원생 벡을 만나 한눈에 반한다.
                             하지만 훈훈했던 그의 첫인상은 잠시일 뿐,
                             감추어진 조의 뒤틀린 이면이 드러난다.
                             """.trimIndent(),
+                        imageUrl = "https://buly.kr/G3Edbfu",
+                        year = 2014,
+                        collectionId = "0",
                     )
                 }.toImmutableList(),
+            isEnd = false,
+            initialPage = 0,
             onWatchCollectionButtonClick = { _, _ -> },
             onMakeCollectionButtonClick = {},
-            onLoadNextPage = {},
+            onLoadNextSession = {},
             modifier =
                 Modifier
                     .padding(PaddingValues())

--- a/app/src/main/java/com/flint/presentation/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.flint.core.common.util.UiState
 import com.flint.domain.model.exploration.ExplorationItemModel
 import com.flint.domain.model.exploration.ExplorationSessionModel
+import com.flint.domain.model.exploration.ExplorationState
 import com.flint.domain.repository.ExplorationRepository
 import com.flint.presentation.explore.uistate.ExploreUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -86,6 +87,12 @@ class ExploreViewModel @Inject constructor(
         session: ExplorationSessionModel,
         previousItems: ImmutableList<ExplorationItemModel>,
     ) {
+        if (session.state == ExplorationState.UNKNOWN) {
+            _uiState.update { UiState.Failure }
+            Timber.e("알 수 없는 탐색 state로 세션을 적용할 수 없어 에러 화면으로 대체합니다.")
+            return
+        }
+
         val mergedItems = if (session.isEnd && previousItems.isNotEmpty()) {
             previousItems
         } else {

--- a/app/src/main/java/com/flint/presentation/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreViewModel.kt
@@ -3,8 +3,9 @@ package com.flint.presentation.explore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.flint.core.common.util.UiState
-import com.flint.domain.model.collection.CollectionsModel
-import com.flint.domain.repository.CollectionRepository
+import com.flint.domain.model.exploration.ExplorationItemModel
+import com.flint.domain.model.exploration.ExplorationSessionModel
+import com.flint.domain.repository.ExplorationRepository
 import com.flint.presentation.explore.uistate.ExploreUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -15,11 +16,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class ExploreViewModel @Inject constructor(
-    private val collectionRepository: CollectionRepository,
+    private val explorationRepository: ExplorationRepository,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<UiState<ExploreUiState>> =
@@ -27,57 +29,74 @@ class ExploreViewModel @Inject constructor(
     val uiState: StateFlow<UiState<ExploreUiState>> = _uiState.asStateFlow()
 
     init {
-        getInitialCollections()
+        loadSession()
     }
 
-    fun loadNextPage() {
-        val currentState: ExploreUiState = (_uiState.value as? UiState.Success)?.data ?: return
-        if (!currentState.canLoadMore) return
-
-        _uiState.update { UiState.Success(currentState.copy(isLoadingMore = true)) }
-
+    private fun loadSession() {
         viewModelScope.launch {
-            fetchCollections(
-                cursor = currentState.nextCursor,
-                currentCollections = currentState.collections
-            )
+            explorationRepository.getExplorationSession()
+                .onSuccess { session -> onSessionLoaded(session) }
+                .onFailure { error ->
+                    _uiState.update { UiState.Failure }
+                    Timber.e(error, "탐색 세션 조회 실패")
+                }
         }
     }
 
-    private fun getInitialCollections() {
+    private suspend fun onSessionLoaded(session: ExplorationSessionModel) {
+        if (session.isEnd && session.hasNext) {
+            fetchNextSession(previousItems = persistentListOf())
+            return
+        }
+
+        applySession(session, previousItems = persistentListOf())
+    }
+
+    fun advanceToNextSession() {
+        val currentState = (_uiState.value as? UiState.Success)?.data ?: return
+        if (!currentState.canAdvance) return
+
+        _uiState.update { UiState.Success(currentState.copy(isLoadingNext = true)) }
+
         viewModelScope.launch {
-            fetchCollections(
-                cursor = null,
-                currentCollections = persistentListOf()
-            )
+            fetchNextSession(previousItems = currentState.items)
         }
     }
 
-    private suspend fun fetchCollections(
-        cursor: Long?,
-        currentCollections: ImmutableList<CollectionsModel.Collection>,
-    ) {
-        collectionRepository.getCollections(
-            cursor = cursor,
-            size = PAGE_SIZE
-        ).onSuccess { collectionsModel: CollectionsModel ->
-            val newData: ImmutableList<CollectionsModel.Collection> =
-                (currentCollections + collectionsModel.data).toImmutableList()
-
-            _uiState.update {
-                UiState.Success(
-                    ExploreUiState(
-                        collections = newData,
-                        nextCursor = collectionsModel.meta.nextCursor,
-                    )
-                )
+    private suspend fun fetchNextSession(previousItems: ImmutableList<ExplorationItemModel>) {
+        explorationRepository.advanceToNextExplorationSession()
+            .onSuccess { session -> applySession(session, previousItems = previousItems) }
+            .onFailure { error ->
+                _uiState.update { current ->
+                    when (current) {
+                        is UiState.Success -> UiState.Success(current.data.copy(isLoadingNext = false))
+                        else -> UiState.Failure
+                    }
+                }
+                Timber.e(error, "다음 탐색 세션 조회 실패")
             }
-        }.onFailure {
-
-        }
     }
 
-    companion object {
-        private const val PAGE_SIZE = 10
+    private fun applySession(
+        session: ExplorationSessionModel,
+        previousItems: ImmutableList<ExplorationItemModel>,
+    ) {
+        val mergedItems = if (session.isEnd && previousItems.isNotEmpty()) {
+            previousItems
+        } else {
+            (previousItems + session.items).toImmutableList()
+        }
+
+        _uiState.update {
+            UiState.Success(
+                ExploreUiState(
+                    items = mergedItems,
+                    state = session.state,
+                    hasNext = session.hasNext,
+                    isLoadingNext = false,
+                    initialPage = if (session.isEnd) mergedItems.size else 0,
+                )
+            )
+        }
     }
 }

--- a/app/src/main/java/com/flint/presentation/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/explore/ExploreViewModel.kt
@@ -32,6 +32,11 @@ class ExploreViewModel @Inject constructor(
         loadSession()
     }
 
+    fun retry() {
+        _uiState.update { UiState.Loading }
+        loadSession()
+    }
+
     private fun loadSession() {
         viewModelScope.launch {
             explorationRepository.getExplorationSession()

--- a/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
+++ b/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
@@ -18,5 +18,5 @@ data class ExploreUiState(
         get() = state == ExplorationState.EMPTY
 
     val canAdvance: Boolean
-        get() = !isLoadingNext && hasNext && (state == ExplorationState.IN_PROGRESS || state == ExplorationState.UNKNOWN)
+        get() = !isLoadingNext && (state == ExplorationState.IN_PROGRESS || state == ExplorationState.UNKNOWN)
 }

--- a/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
+++ b/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
@@ -18,5 +18,5 @@ data class ExploreUiState(
         get() = state == ExplorationState.EMPTY
 
     val canAdvance: Boolean
-        get() = !isLoadingNext && (state == ExplorationState.IN_PROGRESS || state == ExplorationState.UNKNOWN)
+        get() = !isLoadingNext && hasNext && (state == ExplorationState.IN_PROGRESS || state == ExplorationState.UNKNOWN)
 }

--- a/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
+++ b/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
@@ -1,12 +1,22 @@
 package com.flint.presentation.explore.uistate
 
-import com.flint.domain.model.collection.CollectionsModel
+import com.flint.domain.model.exploration.ExplorationItemModel
+import com.flint.domain.model.exploration.ExplorationState
 import kotlinx.collections.immutable.ImmutableList
 
 data class ExploreUiState(
-    val collections: ImmutableList<CollectionsModel.Collection>,
-    val nextCursor: Long? = null,
-    val isLoadingMore: Boolean = false,
+    val items: ImmutableList<ExplorationItemModel>,
+    val state: ExplorationState,
+    val hasNext: Boolean = false,
+    val isLoadingNext: Boolean = false,
+    val initialPage: Int = 0,
 ) {
-    val canLoadMore: Boolean = !isLoadingMore && nextCursor != null
+    val isEnd: Boolean
+        get() = state == ExplorationState.END
+
+    val isEmpty: Boolean
+        get() = state == ExplorationState.EMPTY
+
+    val canAdvance: Boolean
+        get() = !isLoadingNext && (state == ExplorationState.IN_PROGRESS || state == ExplorationState.UNKNOWN)
 }

--- a/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
+++ b/app/src/main/java/com/flint/presentation/explore/uistate/ExploreUiState.kt
@@ -18,5 +18,5 @@ data class ExploreUiState(
         get() = state == ExplorationState.EMPTY
 
     val canAdvance: Boolean
-        get() = !isLoadingNext && (state == ExplorationState.IN_PROGRESS || state == ExplorationState.UNKNOWN)
+        get() = !isLoadingNext && state == ExplorationState.IN_PROGRESS
 }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
@@ -62,7 +62,7 @@ fun OnboardingDoneRoute(
                     if (hasStopped) {
                         hasStopped = false
                         // 그 사이 회원가입이 성공했다면(드문 케이스) Home 이동 로직에 맡기고 여기서는 건드리지 않는다.
-                        if (!currentSignupUiState.isSuccess) {
+                        if (!currentSignupUiState.isSuccess && !currentSignupUiState.isLoading) {
                             currentNavigateUp()
                         }
                     }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingDoneScreen.kt
@@ -11,14 +11,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flint.R
 import com.flint.core.designsystem.component.button.FlintButtonState
@@ -40,6 +45,33 @@ fun OnboardingDoneRoute(
         if (signupUiState.isSuccess) {
             navigateToHome()
         }
+    }
+
+    // End 화면에서 시작하기를 누르지 않은 채 다른 화면(다른 앱 등)에 다녀온 뒤 돌아온 경우,
+    // End 화면에 그대로 머무르지 않고 닉네임 입력 화면으로 되돌린다.
+    // (회원가입이 완료되기 전 사용자가 복귀할 수 있는 온보딩의 가장 마지막 지점은 닉네임 입력 화면)
+    val currentSignupUiState by rememberUpdatedState(signupUiState)
+    val currentNavigateUp by rememberUpdatedState(navigateUp)
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        var hasStopped = false
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_STOP -> hasStopped = true
+                Lifecycle.Event.ON_RESUME -> {
+                    if (hasStopped) {
+                        hasStopped = false
+                        // 그 사이 회원가입이 성공했다면(드문 케이스) Home 이동 로직에 맡기고 여기서는 건드리지 않는다.
+                        if (!currentSignupUiState.isSuccess) {
+                            currentNavigateUp()
+                        }
+                    }
+                }
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     OnboardingDoneScreen(

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingProfileScreen.kt
@@ -67,6 +67,13 @@ fun OnboardingProfileRoute(
     var toastMessage by remember { mutableStateOf("") }
     var isToastSuccess by remember { mutableStateOf(false) }
 
+    // 닉네임 입력 페이지에 (재)진입할 때마다 실행된다.
+    // End 화면까지 갔다가 시작하기를 누르지 않고 뒤로 돌아온 경우를 포함해,
+    // 이전에 입력했던 닉네임이 남아있어도 중복확인 결과는 항상 다시 확인하도록 초기화한다.
+    LaunchedEffect(Unit) {
+        viewModel.resetNicknameCheck()
+    }
+
     LaunchedEffect(Unit) {
         viewModel.profileEvent.collect { event ->
             when (event) {

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -176,6 +176,19 @@ class OnboardingViewModel
         }
     }
 
+    // 닉네임 입력 페이지 재진입 시(예: End 화면에서 뒤로가기) 호출.
+    // 기존에 입력한 닉네임 텍스트는 유지하되, 중복확인 결과는 초기화해
+    // 사용자가 "다음"으로 넘어가기 전 중복확인을 다시 하도록 강제한다.
+    fun resetNicknameCheck() {
+        nicknameCheckJob?.cancel()
+        _uiState.update { currentState ->
+            currentState.copy(
+                isNicknameAvailable = null,
+                nicknameErrorType = null,
+            )
+        }
+    }
+
     fun updateProfileImage(uri: Uri?) {
         _uiState.update { it.copy(profileImageUri = uri) }
     }

--- a/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/flint/presentation/onboarding/OnboardingViewModel.kt
@@ -329,6 +329,9 @@ class OnboardingViewModel
 
     // ---------- onboarding signup ----------
     fun signup() {
+        // 이미 요청이 진행 중이면 중복 호출하지 않는다.
+        if (_signupUiState.value.isLoading) return
+
         viewModelScope.launch {
             _signupUiState.update { it.copy(signupState = UiState.Loading) }
 


### PR DESCRIPTION
## 📮 관련 이슈
Flt 29 안드 자체 qa 임차민
 
## 📌 작업 내용
- 온보딩 닉네임 화면 재진입 시 중복확인 상태 초기화
- 온보딩 End 화면에서 가입 미완료 상태로 백그라운드 이탈 후 복귀 시 닉네임 화면으로 이동 처리
- 탐색(Explore) API를 서버 관리형(`state`/`hasNext`)으로 교체, End 화면 유지 및 위로 스크롤 시 재조회 없이 이전 작품 확인 가능하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 탐색 콘텐츠를 세션 단위로 불러오고 다음 세션으로 이동할 수 있습니다.
  * 콘텐츠의 제목, 설명, 이미지, 연도 등의 정보가 표시됩니다.
  * 콘텐츠가 없거나 탐색이 종료된 상태를 안내합니다.

* **버그 수정**
  * 세션 로딩 중 진행 상태가 표시됩니다.
  * 탐색 요청 실패 시 재시도할 수 있습니다.
  * 온보딩 재진입 시 닉네임 확인 상태가 초기화됩니다.
  * 회원가입 없이 온보딩을 이탈하면 이전 화면으로 돌아갑니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->